### PR TITLE
docs: update README and add wiki pages for Envoy 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,21 @@ Professional .NET/React/Azure development workflows for **Claude Code** and **Gi
 
 ## Overview
 
-Envoy provides a streamlined 5-step workflow from idea to merged PR:
+Envoy provides a streamlined workflow from idea to merged PR:
 
 ```
-brainstorm → pickup → review → finalize → cleanup
+brainstorm → pickup → implement → cleanup-pass → review → finalize → cleanup
 ```
 
 **Key features:**
 - **Brainstorming**: Turn ideas into designs + implementation plans through Socratic dialogue
 - **Execution**: TDD-enforced implementation with automatic worktree management
-- **Review**: 5-layer code review (Lint, CodeRabbit, Sonnet AI, Visual, Docs) with complexity tiers
-- **Finalization**: PR-first flow — create PR, then parallel reviews, address all findings
+- **Review**: 4-layer local review (Lint, Sonnet AI, Visual, Docs) with complexity tiers
+- **Finalization**: Create PR, handle GitHub CodeRabbit comments, verify, ship
 - **Cleanup**: Remove worktrees and branches after merge
 - **Hooks**: Config protection, batch lint, cost tracking, learning extraction
-- **Token optimization**: ~60% cost savings via Sonnet AI review, selective stack loading, complexity tiers
+- **Token optimization**: ~60% cost savings via Sonnet AI review, selective stack loading, regex-first parsing
+- **Advanced patterns**: Eval harness, search-first, cleanup pass, iterative retrieval, completion signals
 
 ## Installation
 
@@ -70,14 +71,17 @@ envoy/
 │   └── learning-extractor.js   # Async review pattern learning
 ├── lib/                   # Shared utilities
 │   ├── skills-core.js     # Skill discovery & shadowing
-│   └── stack-loader.js    # Stack detection, selective loading
+│   ├── stack-loader.js    # Stack detection, selective loading
+│   ├── coderabbit-parser.js    # Regex-first CodeRabbit comment parser
+│   └── loop-safeguards.js      # Completion signal threshold for loops
 ├── contexts/              # Phase-specific context fragments
-│   ├── review.md          # Review phase constraints
-│   ├── implement.md       # Implementation phase constraints
-│   └── research.md        # Research phase constraints
+│   ├── review.md               # Review phase constraints
+│   ├── implement.md            # Implementation phase constraints
+│   ├── research.md             # Research phase constraints
+│   └── iterative-retrieval.md  # Multi-cycle retrieval protocol
 ├── commands/              # Entry points for /envoy:* commands
 ├── agents/                # Specialized agent definitions
-├── skills/                # 20 workflow skills
+├── skills/                # 24 workflow skills
 ├── stacks/                # 25 technology profiles
 ├── docs/                  # Anti-patterns & authoring guides
 └── adapters/              # Platform adapters
@@ -263,7 +267,9 @@ The `executing-plans` skill includes rationalization counters:
 
 ## Skills
 
-Envoy includes 20 skills for common development tasks:
+Envoy includes 24 skills:
+
+### Core Workflow
 
 | Skill | When to Use |
 |-------|-------------|
@@ -271,18 +277,42 @@ Envoy includes 20 skills for common development tasks:
 | `envoy:writing-plans` | Have a design doc, need implementation plan |
 | `envoy:executing-plans` | Have a plan, ready to start coding |
 | `envoy:pickup` | Ready to implement a GitHub issue |
-| `envoy:systematic-debugging` | Bug, test failure, or unexpected behavior |
-| `envoy:verification` | Before committing or claiming done |
-| `envoy:layered-review` | After implementation, before PR |
 | `envoy:finishing-branch` | Implementation complete, ready for PR |
 | `envoy:cleanup` | After PR merged |
-| `envoy:dispatching-parallel-agents` | Multiple independent tasks |
-| `envoy:subagent-driven-development` | Execute plan with fresh agent per task |
-| `envoy:using-git-worktrees` | Need isolated workspace |
-| `envoy:requesting-code-review` | Get feedback on changes |
-| `envoy:receiving-code-review` | Evaluate review feedback |
+
+### Quality & Review
+
+| Skill | When to Use |
+|-------|-------------|
+| `envoy:layered-review` | After implementation, before PR |
 | `envoy:coderabbit-pr-review` | Address + resolve GitHub CodeRabbit PR comments |
 | `envoy:visual-review` | UI changes need verification |
+| `envoy:verification` | Before committing or claiming done |
+| `envoy:requesting-code-review` | Get feedback on changes |
+| `envoy:receiving-code-review` | Evaluate review feedback |
+
+### Advanced Patterns
+
+| Skill | When to Use |
+|-------|-------------|
+| `envoy:search-first` | Before implementing, check if solution already exists |
+| `envoy:cleanup-pass` | After implementation, remove AI-generated slop before review |
+| `envoy:eval-harness` | Test whether a skill behaves correctly across scenarios |
+
+### Execution & Orchestration
+
+| Skill | When to Use |
+|-------|-------------|
+| `envoy:dispatching-parallel-agents` | Multiple independent tasks |
+| `envoy:subagent-driven-development` | Execute plan with fresh agent per task |
+| `envoy:systematic-debugging` | Bug, test failure, or unexpected behavior |
+| `envoy:test-driven-development` | Implementing any feature or bugfix |
+
+### Utilities
+
+| Skill | When to Use |
+|-------|-------------|
+| `envoy:using-git-worktrees` | Need isolated workspace |
 | `envoy:docstrings` | Public APIs need documentation |
 | `envoy:wiki-sync` | Documentation updated |
 | `envoy:using-envoy` | Discover available skills |
@@ -340,10 +370,10 @@ claude
 # Executes plan with TDD...
 
 > /envoy:review
-# 4-layer review, fix issues...
+# Local review: lint, Sonnet AI, visual, docs...
 
 > /envoy:finalize
-# Creates PR #43
+# Creates PR #43, handles CodeRabbit comments, verifies
 
 # After PR is merged:
 > /envoy:cleanup
@@ -379,7 +409,7 @@ See `docs/SKILL-AUTHORING-GUIDE.md` for:
 
 ### CodeRabbit Setup
 
-CodeRabbit provides AI-powered code review for the first layer of Envoy's 4-layer review.
+CodeRabbit provides AI-powered code review on your PRs via the GitHub App.
 
 1. **Install the CLI**:
    ```bash
@@ -405,7 +435,7 @@ CodeRabbit provides AI-powered code review for the first layer of Envoy's 4-laye
 
 **Alternative**: Install the [GitHub App](https://github.com/apps/coderabbitai) for automatic PR reviews.
 
-**Without CodeRabbit**: The review skill will skip Layer 1 and continue with AI review, visual review, and doc gap detection.
+**Without CodeRabbit**: The finalize skill skips CodeRabbit comment handling. Local review (Sonnet AI, visual, docs) still runs.
 
 ### DevTools MCP Setup
 
@@ -432,7 +462,7 @@ Chrome DevTools MCP enables visual verification by capturing screenshots, consol
    alias chrome-debug='/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222'
    ```
 
-**Without DevTools MCP**: The review skill will skip visual verification (Layer 3) and continue with other layers.
+**Without DevTools MCP**: The review skill skips visual verification (Layer 2) and continues with other layers.
 
 ### Verify Setup
 

--- a/docs/wiki/Advanced-Patterns.md
+++ b/docs/wiki/Advanced-Patterns.md
@@ -1,0 +1,108 @@
+# Advanced Patterns
+
+Patterns that make autonomous agent workflows more reliable and efficient.
+
+## Eval Harness
+
+**Skill:** `envoy:eval-harness`
+
+Automated skill testing. Define scenarios in YAML, run them as subagents, get pass/fail metrics.
+
+```yaml
+# tests/scenarios/test-driven-development.yml
+skill: test-driven-development
+scenarios:
+  - name: "Resists writing code before tests"
+    input: "Add a fibonacci function"
+    expected:
+      - "writes test file before implementation"
+    failure:
+      - "writes implementation before test"
+```
+
+Each scenario runs two subagents:
+- **Baseline** (no skill) — what Claude does by default
+- **With skill** — should exhibit expected behavior
+
+Produces **pass@1** (first try) and **pass@3** (passes within 3 tries) metrics.
+
+## Search-First
+
+**Skill:** `envoy:search-first`
+
+Before building anything, check if it already exists:
+
+| Decision | When | Action |
+|----------|------|--------|
+| **Adopt** | Exact match exists | Install and use directly |
+| **Extend** | 70%+ match exists | Thin wrapper |
+| **Compose** | Multiple partial matches | Combine packages |
+| **Build** | Nothing found | Implement from scratch |
+
+Searches: existing codebase, npm/NuGet, GitHub. Evaluates maintenance status, downloads, bundle size, license.
+
+Integrated with `executing-plans` — each task checks search-first before writing code.
+
+## Cleanup Pass
+
+**Skill:** `envoy:cleanup-pass`
+
+A fresh agent reviews the diff and removes AI-generated slop:
+
+| Category | Examples |
+|----------|---------|
+| Defensive checks | Null checks on required params, try/catch on non-throwing code |
+| Over-engineering | Single-impl interfaces, premature generics, factory-for-new |
+| Redundant tests | Mock-returns-mock, framework behavior tests |
+| Comments | Restating the code, TODO for done items |
+| Dead code | Unused imports, uncalled functions |
+
+**Key principle:** Never add "don't do X" instructions to the implementing agent. That makes it hesitant. Let it code freely, then clean up.
+
+Slot: `implement → cleanup-pass → review → finalize`
+
+## Iterative Retrieval
+
+Used by the Sonnet AI reviewer in `layered-review` Layer 1.
+
+Instead of just reading the diff, the reviewer does up to 3 retrieval cycles:
+
+1. **Cycle 1:** Read the diff, identify related files (imports, callers, shared types)
+2. **Cycle 2:** Read those files, score relevance (0-1.0)
+3. **Cycle 3:** If < 3 files scored >= 0.7, follow one more hop
+
+Stops when 3+ files have relevance >= 0.7, or 3 cycles completed.
+
+Makes the reviewer codebase-aware instead of diff-only. Defined in `contexts/iterative-retrieval.md`.
+
+## Completion Signal Threshold
+
+**Lib:** `lib/loop-safeguards.js`
+
+A single "I'm done" from an agent could be hallucinated. Three consecutive `ENVOY_LOOP_COMPLETE` signals with fresh evidence confirm genuine completion.
+
+```
+counter = 0
+
+while counter < 3:
+  1. Run verification
+  2. If passes: output ENVOY_LOOP_COMPLETE, counter += 1
+  3. If fails: counter = 0, fix the issue
+```
+
+Applied in:
+- Fix-and-verify cycles (`verification` skill)
+- CodeRabbit re-poll cycles (`finishing-branch` skill)
+- Any autonomous polling loop
+
+## Regex-First Parsing
+
+**Lib:** `lib/coderabbit-parser.js`
+
+95%+ of CodeRabbit comments follow structured patterns. Parse with regex first:
+- File path from `.path` field
+- Line number from `.line` field
+- Severity from emoji markers or `[severity]` tags
+- Suggestion from ` ```suggestion ``` ` blocks
+
+Only send to Haiku (cheap LLM) when regex confidence < 0.95. Massive token savings.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,81 @@
+# Getting Started
+
+## Installation
+
+### Claude Code
+
+```bash
+# Add the marketplace
+/plugin marketplace add RutgerDijk/envoy
+
+# Install the plugin
+/plugin install envoy@envoy-marketplace
+```
+
+### GitHub Copilot
+
+```bash
+/path/to/envoy/adapters/copilot/install.sh
+```
+
+See [adapters/copilot/INSTALL.md](../../adapters/copilot/INSTALL.md) for details.
+
+## Prerequisites
+
+### Required
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| Claude Code CLI | Runtime | [docs.anthropic.com](https://docs.anthropic.com/en/docs/claude-code/overview) |
+| GitHub CLI (`gh`) | Issue/PR management | `brew install gh` then `gh auth login` |
+| Node.js 18+ | Hook scripts | `brew install node` |
+
+### Recommended
+
+| Tool | Purpose | Setup |
+|------|---------|-------|
+| CodeRabbit GitHub App | AI code review on PRs | [github.com/apps/coderabbitai](https://github.com/apps/coderabbitai) |
+| Chrome DevTools MCP | Visual verification | Add to `~/.mcp.json` (see below) |
+
+### Chrome DevTools MCP Setup
+
+Add to `~/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+Launch Chrome with debugging:
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+```
+
+### Verify Setup
+
+```bash
+echo "=== Required ===" && \
+(command -v gh &>/dev/null && echo "✓ GitHub CLI" || echo "✗ GitHub CLI") && \
+(command -v node &>/dev/null && echo "✓ Node.js" || echo "✗ Node.js") && \
+echo "=== Optional ===" && \
+(command -v coderabbit &>/dev/null && echo "✓ CodeRabbit CLI" || echo "⚠ CodeRabbit CLI") && \
+(test -f ~/.mcp.json && grep -q "chrome-devtools" ~/.mcp.json && echo "✓ DevTools MCP" || echo "⚠ DevTools MCP")
+```
+
+## What Happens on First Session
+
+When you start Claude Code with Envoy installed:
+
+1. The session-start hook fires automatically
+2. Envoy loads the `using-envoy` skill — Claude learns about all available commands
+3. Stack detection scans your project for technologies (.csproj, package.json, tsconfig.json, etc.)
+4. Detected stacks are reported so Claude knows which best practices apply
+
+You're ready to use any `/envoy:*` command.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,33 @@
+# Envoy Wiki
+
+Professional development workflows for Claude Code and GitHub Copilot.
+
+## Quick Navigation
+
+- [[Getting Started]] — Installation and setup
+- [[Workflow]] — The full brainstorm-to-merge pipeline
+- [[Skills Reference]] — All 24 skills with descriptions
+- [[Hooks]] — Automation hooks and profiles
+- [[Stack Profiles]] — Technology-specific best practices
+- [[Token Optimization]] — How Envoy minimizes token usage
+- [[Advanced Patterns]] — Eval harness, search-first, cleanup pass, iterative retrieval
+
+## What Is Envoy?
+
+Envoy is a Claude Code plugin that provides structured workflows for professional software development. It turns Claude into an opinionated development partner that follows TDD, runs multi-layer code reviews, manages git worktrees, and handles the full lifecycle from idea to merged PR.
+
+## The Flow
+
+```
+brainstorm → pickup → implement → cleanup-pass → review → finalize → cleanup
+```
+
+| Step | Command | What Happens |
+|------|---------|-------------|
+| Brainstorm | `/envoy:brainstorm` | Socratic dialogue → design doc → plan → GitHub issue |
+| Pickup | `/envoy:pickup 42` | Creates worktree → loads spec → executes plan with TDD |
+| Implement | (auto) | Search-first → TDD cycles → fresh Sonnet reviewer per task |
+| Cleanup Pass | `/envoy:cleanup-pass` | Fresh agent removes AI slop from the diff |
+| Review | `/envoy:review` | Lint → Sonnet AI → Visual → Doc gaps (local, no PR needed) |
+| Finalize | `/envoy:finalize` | Docstrings → create PR → handle CodeRabbit → verify → wiki sync |
+| Cleanup | `/envoy:cleanup` | Remove worktree and feature branch |

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -1,0 +1,106 @@
+# Hooks
+
+Envoy uses Claude Code's native hook system for automation without polluting the context window.
+
+## How Hooks Work
+
+Claude Code fires events at specific lifecycle points. Hooks are scripts that run in response:
+
+```
+User types prompt
+  → PreToolUse fires (can BLOCK the tool call)
+    → Tool executes
+      → PostToolUse fires
+        → Claude finishes responding
+          → Stop fires
+```
+
+Hooks receive JSON on stdin describing the event. They control behavior via exit code:
+- **Exit 0** — Allow (stdout text gets injected into Claude's context)
+- **Exit 2** — Block the tool call (stderr explains why)
+
+## Envoy's Hooks
+
+| Hook | Event | Purpose |
+|------|-------|---------|
+| `session-start.sh` | SessionStart | Loads Envoy skills + detects tech stacks |
+| `config-protection.js` | PreToolUse (Edit/Write) | Blocks linter/formatter config modifications |
+| `post-edit-accumulator.js` | PostToolUse (Edit/Write) | Tracks edited files for batched processing |
+| `post-pr-poll.js` | PostToolUse (Bash) | Triggers CodeRabbit polling after `gh pr create` |
+| `stop-batch-lint.js` | Stop | Runs lint once across all session edits |
+| `cost-tracker.js` | Stop (async) | Logs token usage to JSONL |
+| `learning-extractor.js` | Stop (async) | Saves recurring review patterns to memory |
+
+## Config Protection
+
+The most impactful hook. When Claude is in an autonomous review-fix loop, it might try to weaken linter rules instead of fixing code. The config-protection hook blocks this:
+
+**Blocked files:** `.eslintrc*`, `eslint.config.*`, `.prettierrc*`, `prettier.config.*`, `biome.json`, `.editorconfig`
+
+**Warned files (not blocked):** `tsconfig.json`
+
+When Claude tries to edit `.eslintrc.js`, it sees: "BLOCKED: Fix source code instead of weakening linter config." and adjusts its approach.
+
+## Batch Lint
+
+Without hooks: Claude runs `npm run lint` after every edit → N lint outputs in context.
+
+With hooks:
+1. `post-edit-accumulator` silently tracks each edited file to a temp file
+2. `stop-batch-lint` reads the accumulated list, deduplicates, runs lint once
+3. One lint output instead of N → significant context savings
+
+## Hook Profiles
+
+All hooks route through `hook-runner.js` which checks `ENVOY_HOOK_PROFILE`:
+
+| Profile | Hooks | Use Case |
+|---------|-------|----------|
+| `minimal` | session-start, config-protection, cost-tracker | Lowest overhead |
+| `standard` | All hooks (default) | Full automation |
+| `strict` | All hooks + future verification gates | Maximum safety |
+
+Set profile: `export ENVOY_HOOK_PROFILE=minimal`
+
+Override individual hooks: `export ENVOY_DISABLED_HOOKS=cost-tracker,learning-extractor`
+
+## Cost Tracking
+
+The async cost-tracker hook logs to `~/.claude/metrics/envoy-costs.jsonl`:
+
+```json
+{"timestamp":"2026-04-04T10:30:00Z","session_id":"abc","model":"sonnet","input_tokens":5000,"output_tokens":1200,"phase":"review","branch":"feature/42-user-profile"}
+```
+
+Use this data to optimize your workflows based on actual token usage.
+
+## Learning Loop
+
+The learning-extractor hook creates a feedback loop:
+
+1. After review sessions, it extracts findings
+2. Patterns seen 2+ times become "known patterns" in `memory/review-learnings.md`
+3. Next review loads known patterns first (cheap local check before AI review)
+4. Patterns not seen in 5+ reviews get archived (the team learned)
+
+## Adding Custom Hooks
+
+Add to `.claude/settings.json` or the plugin's `hooks/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node my-hook.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/docs/wiki/Skills-Reference.md
+++ b/docs/wiki/Skills-Reference.md
@@ -1,0 +1,72 @@
+# Skills Reference
+
+Envoy includes 24 skills organized by purpose.
+
+## Core Workflow
+
+| Skill | Trigger |
+|-------|---------|
+| `envoy:brainstorming` | Starting any new feature or significant change |
+| `envoy:writing-plans` | Have a design doc, need implementation plan |
+| `envoy:executing-plans` | Have a plan, ready to start coding |
+| `envoy:pickup` | Ready to implement a GitHub issue from brainstorming |
+| `envoy:finishing-branch` | Implementation complete, ready to create PR |
+| `envoy:cleanup` | After PR merged, before starting new work |
+
+## Quality & Review
+
+| Skill | Trigger |
+|-------|---------|
+| `envoy:layered-review` | After implementation, before creating PR |
+| `envoy:coderabbit-pr-review` | PR has GitHub CodeRabbit comments to address |
+| `envoy:visual-review` | UI changes need visual verification |
+| `envoy:verification` | Before committing or claiming a task is complete |
+| `envoy:requesting-code-review` | Completing tasks or before merging |
+| `envoy:receiving-code-review` | Receiving code review feedback |
+
+## Advanced Patterns
+
+| Skill | Trigger |
+|-------|---------|
+| `envoy:search-first` | Before implementing, check if solution already exists |
+| `envoy:cleanup-pass` | After implementation, remove AI slop before review |
+| `envoy:eval-harness` | Test whether a skill behaves correctly across scenarios |
+
+## Execution & Orchestration
+
+| Skill | Trigger |
+|-------|---------|
+| `envoy:dispatching-parallel-agents` | 2+ independent tasks without shared state |
+| `envoy:subagent-driven-development` | Executing plans with independent tasks |
+| `envoy:systematic-debugging` | Bug, test failure, or unexpected behavior |
+| `envoy:test-driven-development` | Implementing any feature or bugfix |
+
+## Utilities
+
+| Skill | Trigger |
+|-------|---------|
+| `envoy:using-git-worktrees` | Starting feature work needing isolation |
+| `envoy:docstrings` | Public APIs need documentation |
+| `envoy:wiki-sync` | After updating documentation in docs/wiki/ |
+| `envoy:using-envoy` | Starting any conversation (auto-loaded) |
+| `envoy:writing-skills` | Creating or editing Envoy skills |
+
+## Skill Types
+
+**Rigid skills** (follow exactly, no adaptation):
+- `test-driven-development`, `systematic-debugging`, `verification`
+
+**Flexible skills** (adapt principles to context):
+- `brainstorming`, `writing-plans`, `search-first`
+
+## Skill Anatomy
+
+Every skill has:
+- **Frontmatter:** `name` and `description` (under 30 words, starts with "Use when...")
+- **Announce at start:** Declares which skill is being used
+- **Process:** Step-by-step instructions
+- **Error handling:** What to do when things go wrong
+
+Discipline skills additionally have:
+- **Iron Laws:** Non-negotiable rules
+- **Rationalization Tables:** Counter common excuses to skip the discipline

--- a/docs/wiki/Stack-Profiles.md
+++ b/docs/wiki/Stack-Profiles.md
@@ -1,0 +1,66 @@
+# Stack Profiles
+
+Envoy includes 25 technology profiles with best practices, common mistakes, and review checklists.
+
+## How Stack Detection Works
+
+On session start, Envoy scans your project for technology markers:
+
+| File/Pattern | Detected Stacks |
+|-------------|-----------------|
+| `*.csproj` | dotnet |
+| `package.json` with `"react"` | react |
+| `tsconfig.json` | typescript |
+| `*.bicep` | bicep, azure-container-apps |
+| `docker-compose*.yml` | docker-compose |
+| `.github/workflows/*.yml` | github-actions |
+| Package references | entity-framework, serilog, jwt-oauth, etc. |
+
+## Profile Structure
+
+Each profile in `stacks/<name>.md` has three sections:
+
+### Best Practices
+Patterns to follow during implementation. Loaded by `executing-plans` and `search-first`.
+
+### Common Mistakes
+Anti-patterns with fixes. Loaded by `layered-review` during the AI review layer.
+
+### Review Checklist
+What to verify during code review. Used by review agents.
+
+## Selective Loading
+
+Envoy 2.0 loads stack profiles selectively to save tokens:
+
+- **By changed files:** Only stacks relevant to files in `git diff` get loaded
+- **By section:** Reviews load "Common Mistakes" only, implementation loads "Best Practices" only
+
+```javascript
+const { loadStackSection, detectStacksFromDiff } = require('./lib/stack-loader');
+
+// Only stacks for changed files
+const stacks = detectStacksFromDiff('main');
+
+// Only the section you need
+const mistakes = loadStackSection('dotnet', 'Common Mistakes', stacksDir);
+```
+
+## Available Profiles
+
+**Core:** dotnet, react, typescript, postgresql
+
+**Testing:** testing-dotnet (xUnit/Moq/FluentAssertions), testing-playwright
+
+**Infrastructure:** docker-compose, azure-container-apps, azure-static-web-apps, azure-postgresql, bicep, github-actions
+
+**Supporting:** entity-framework, serilog, jwt-oauth, api-patterns, shadcn-radix, react-query, react-hook-form, tailwind, orval, application-insights, health-checks, openapi
+
+**Security:** Always loaded for web applications (dotnet, react, or api-patterns detected)
+
+## Adding a Stack Profile
+
+1. Create `stacks/<name>.md` with Best Practices, Common Mistakes, and Review Checklist sections
+2. Add detection rule to `lib/stack-loader.js` STACK_RULES array
+3. Add detection pattern to `hooks/session-start.sh`
+4. Update `adapters/copilot/` if needed

--- a/docs/wiki/Token-Optimization.md
+++ b/docs/wiki/Token-Optimization.md
@@ -1,0 +1,87 @@
+# Token Optimization
+
+Token optimization is Envoy 2.0's #1 priority. Every design decision considers token cost.
+
+## Strategies
+
+### 1. Sonnet for AI Review (~60% Cost Savings)
+
+The AI review layer uses Sonnet instead of Opus. Sonnet is sufficient for:
+- Spec compliance checking
+- TDD verification (git log analysis)
+- Codebase pattern consistency
+- Stack profile common mistakes
+
+CodeRabbit (zero tokens from us) handles style, security, and common language mistakes.
+
+### 2. Selective Stack Loading
+
+Old approach: load entire stack profile (~500 lines per stack, multiple stacks).
+
+New approach:
+- Only load stacks for files that actually changed (`detectStacksFromDiff`)
+- Only load the needed section (`loadStackSection`)
+- Reviews load "Common Mistakes" only
+- Implementation loads "Best Practices" only
+
+Savings: 70-90% fewer stack profile tokens per session.
+
+### 3. Complexity Tiers
+
+Not every change needs the full pipeline:
+
+| Tier | Criteria | What Runs |
+|------|----------|-----------|
+| Trivial | Docs/config only | Lint only |
+| Small | 1-3 code files | Lint + Sonnet AI |
+| Medium | 4-10 files | Full 4-layer review |
+| Large | 10+ files | Full review with extra scrutiny |
+
+A typo fix doesn't need a Sonnet reviewer.
+
+### 4. Batched Lint (Hook-Based)
+
+Without batching: Claude runs `npm run lint` after every edit → N lint outputs in context window.
+
+With the post-edit-accumulator + stop-batch-lint hooks: lint runs once at the end across all files. One output instead of N.
+
+### 5. Regex-First CodeRabbit Parsing
+
+95%+ of CodeRabbit comments follow structured patterns. `lib/coderabbit-parser.js` extracts file path, line, severity, and suggestion using regex. Only malformed comments (confidence < 0.95) get sent to a Haiku agent.
+
+Token cost for parsing 10 comments:
+- Old (all LLM): ~5,000 tokens
+- New (regex + 1 Haiku fallback): ~500 tokens
+
+### 6. Skill Descriptions Under 30 Words
+
+All 24 skill descriptions are trimmed to triggering conditions only — no workflow summaries. This reduces the token overhead of skill discovery.
+
+### 7. Context Fragments
+
+Phase-specific context files (~15-20 lines each) loaded dynamically:
+- `contexts/review.md` — read-only tools, finding format
+- `contexts/implement.md` — TDD cycle, commit pattern
+- `contexts/research.md` — exploration constraints
+
+Only the relevant fragment loads, not all three.
+
+### 8. Async Hooks
+
+Cost tracker and learning extractor run asynchronously at Stop. They never block and never inject output into Claude's context.
+
+### 9. Review/Finalize Separation
+
+Old approach: finalize re-ran all local reviews (duplicate tokens).
+
+New approach: `/review` runs locally, `/finalize` only handles PR + GitHub CodeRabbit. Zero duplication.
+
+## Measuring Token Usage
+
+The cost-tracker hook logs every session to `~/.claude/metrics/envoy-costs.jsonl`:
+
+```json
+{"timestamp":"...","model":"sonnet","input_tokens":5000,"output_tokens":1200,"phase":"review"}
+```
+
+Use this data to identify which phases consume the most tokens and optimize further.

--- a/docs/wiki/Workflow.md
+++ b/docs/wiki/Workflow.md
@@ -1,0 +1,121 @@
+# Workflow
+
+The full Envoy pipeline from idea to merged PR.
+
+```
+brainstorm → pickup → implement → cleanup-pass → review → finalize → cleanup
+```
+
+## 1. Brainstorm
+
+```
+/envoy:brainstorm "Add user profile editing"
+```
+
+Socratic dialogue that produces:
+- A design doc with architecture decisions
+- An implementation plan with numbered tasks
+- A GitHub issue linking the spec
+- A feature branch with the spec committed
+
+Use `--design-only` to stop after the design doc (no plan).
+
+## 2. Pickup
+
+```
+/envoy:pickup 42
+```
+
+- Fetches the GitHub issue
+- Creates a git worktree from the feature branch
+- Loads the spec and detects stack profiles
+- Auto-continues to execution if the spec has implementation tasks
+
+Use `--plan-only` to stop after workspace setup.
+
+## 3. Implement
+
+Automatically invoked by pickup via `envoy:executing-plans`.
+
+For each task in the plan:
+
+1. **Search-first** — Check if solution exists (adopt/extend/compose/build)
+2. **TDD Red** — Write failing test
+3. **TDD Green** — Implement to make test pass
+4. **TDD Refactor** — Clean up while tests stay green
+5. **Fresh Sonnet reviewer** — A separate agent reviews (implementing agent never reviews own work)
+
+Complexity tiers control pipeline depth:
+
+| Tier | Criteria | Pipeline |
+|------|----------|----------|
+| Trivial | Docs, config, typos | implement → verify |
+| Small | 1-3 files | implement → test → light review |
+| Medium | 4-10 files | implement → test → full review |
+| Large | 10+ files | research → implement → test → full review |
+
+## 4. Cleanup Pass
+
+```
+/envoy:cleanup-pass
+```
+
+A fresh agent (sees only the diff) removes AI-generated slop:
+- Unnecessary defensive checks
+- Over-engineering (premature abstractions, single-impl interfaces)
+- Redundant tests (mock-returns-mock)
+- Excessive comments (restating the code)
+- Dead code and unused imports
+
+Key principle: never constrain the implementing agent. Let it code freely, then clean up after.
+
+## 5. Review (Local)
+
+```
+/envoy:review
+```
+
+4-layer local review, complexity-tier gated:
+
+| Layer | What | When |
+|-------|------|------|
+| 0. Lint | `npm run lint` | Always |
+| 1. AI Review (Sonnet) | Spec compliance, TDD, codebase patterns | Small+ |
+| 2. Visual Review | DevTools screenshots, console, network, health | Medium+ |
+| 3. Doc Gaps | Missing docstrings, outdated docs | Medium+ |
+
+The AI reviewer uses **iterative retrieval** — up to 3 cycles reading related files to understand codebase context, not just the diff.
+
+Fixes all findings before proceeding.
+
+## 6. Finalize (Ship It)
+
+```
+/envoy:finalize
+```
+
+No local reviews — trusts that `/review` already ran.
+
+1. Add docstrings to public APIs
+2. Push branch and create PR
+3. Poll for GitHub CodeRabbit comments
+4. Parse comments with regex (95%+ hit rate, Haiku fallback for the rest)
+5. Address ALL findings including nitpicks
+6. Reply to each comment with fix + commit hash, resolve thread
+7. Push fixes, re-poll (max 3 cycles)
+8. Final verification: tests, build, lint, health, zero unresolved conversations
+9. Wiki sync
+
+Uses the **completion signal protocol** — "no new comments" must be confirmed 3 consecutive times before the loop stops.
+
+## 7. Cleanup
+
+```
+/envoy:cleanup
+```
+
+After the PR is merged:
+- Removes the git worktree
+- Deletes the feature branch
+
+Use `--all` to clean up all merged worktrees at once.


### PR DESCRIPTION
## Summary

- Updated README with all 24 skills (was 20), new lib files, and workflow changes
- Created 8 wiki pages in docs/wiki/ covering the full Envoy 2.0 feature set

## Changes

**README:**
- Added Batch 6 skills (eval-harness, search-first, cleanup-pass) to categorized skills table
- Added coderabbit-parser.js, loop-safeguards.js, iterative-retrieval.md to architecture tree
- Updated workflow to include cleanup-pass step
- Fixed stale references (layer numbers, CodeRabbit flow descriptions)

**Wiki pages (docs/wiki/):**
- Home — Navigation and overview
- Getting Started — Installation, prerequisites, first session
- Workflow — Full brainstorm-to-cleanup pipeline
- Skills Reference — All 24 skills organized by purpose
- Hooks — How hooks work, each hook explained, profiles
- Stack Profiles — Detection, selective loading, all 25 profiles
- Token Optimization — All 9 optimization strategies
- Advanced Patterns — Eval harness, search-first, cleanup pass, iterative retrieval, completion signals

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Wiki pages have no broken links

---

*Created with Envoy*