### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional .NET/React/Azure development workflows for Claude Code",
-    "version": "1.2.0"
+    "version": "2.0.0"
   },
   "plugins": [
     {
@@ -15,8 +15,8 @@
         "source": "github",
         "repo": "RutgerDijk/envoy"
       },
-      "description": "Professional .NET/React/Azure development workflows with handoff-ready artifacts, 5-layer review, and visual verification",
-      "version": "1.2.0",
+      "description": "Professional development workflows with token-optimized review, hooks, and autonomous agent patterns",
+      "version": "2.0.0",
       "author": {
         "name": "Rutger Dijkstra"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "envoy",
-  "description": "Professional .NET/React/Azure development workflows with handoff-ready artifacts, 5-layer review, and visual verification",
-  "version": "1.2.0",
+  "description": "Professional development workflows with token-optimized review, hooks, and autonomous agent patterns",
+  "version": "2.0.0",
   "author": {
     "name": "Rutger Dijkstra"
   },


### PR DESCRIPTION
## Summary

Bumps plugin and marketplace version from 1.2.0 to 2.0.0 for the Envoy 2.0 release.

This was supposed to be in PR #4 but the commit was pushed after the merge.

---

*Created with Envoy*