### PR TITLE
Auto-fix CI/CD failures + exponential CodeRabbit polling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "Claude Code marketplace entries for the Envoy professional development workflow plugin and its editorial bundles.",
-    "version": "2.1.1"
+    "version": "2.1.2"
   },
   "plugins": [
     {
       "name": "envoy",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Expose the full Envoy professional development workflow plugin through a single marketplace entry.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -40,7 +40,7 @@
     },
     {
       "name": "envoy-bundle-essentials",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Essentials\" bundle — core brainstorm-to-merge workflow: brainstorm, pickup, executing-plans, finishing-branch, cleanup.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -60,7 +60,7 @@
     },
     {
       "name": "envoy-bundle-code-review",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Code Review\" bundle — layered review, visual review, quick review, CodeRabbit PR handling, requesting and receiving code review.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -80,7 +80,7 @@
     },
     {
       "name": "envoy-bundle-tdd-quality",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"TDD & Quality\" bundle — test-driven development, systematic debugging, verification, eval harness.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -101,7 +101,7 @@
     },
     {
       "name": "envoy-bundle-orchestration",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Agent Orchestration\" bundle — parallel agent dispatching, subagent-driven development, plan execution strategies.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -122,7 +122,7 @@
     },
     {
       "name": "envoy-bundle-documentation",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Documentation\" bundle — docstrings for public APIs, wiki sync, skill authoring guide.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -142,7 +142,7 @@
     },
     {
       "name": "envoy-bundle-self-learning",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Self-Learning\" bundle — graduated pattern learning, cross-PR CodeRabbit aggregation, user correction detection.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -163,7 +163,7 @@
     },
     {
       "name": "envoy-bundle-hooks",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Hooks\" bundle — config protection, batch lint, cost tracking, learning extraction, CodeRabbit aggregation, correction detection.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -184,7 +184,7 @@
     },
     {
       "name": "envoy-bundle-dotnet",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \".NET\" stack bundle — .NET, Entity Framework, API patterns, xUnit/Moq/FluentAssertions profiles.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -205,7 +205,7 @@
     },
     {
       "name": "envoy-bundle-react-typescript",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"React & TypeScript\" stack bundle — React, TypeScript, Tailwind, shadcn/Radix, React Query, React Hook Form profiles.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -226,7 +226,7 @@
     },
     {
       "name": "envoy-bundle-azure-devops",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Azure & DevOps\" stack bundle — Azure Container Apps, Static Web Apps, Bicep, GitHub Actions, Docker Compose profiles.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -247,7 +247,7 @@
     },
     {
       "name": "envoy-bundle-security",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Security\" bundle — security stack profile, JWT/OAuth patterns, security audit agent.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -267,7 +267,7 @@
     },
     {
       "name": "envoy-bundle-advanced-patterns",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"Advanced Patterns\" bundle — search-first, cleanup pass, iterative retrieval, completion signals, pressure-test scenarios.",
       "author": {
         "name": "Rutger Dijkstra",
@@ -287,7 +287,7 @@
     },
     {
       "name": "envoy-bundle-copilot-adapter",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Install the \"GitHub Copilot\" adapter — prompts, instructions, and agents for GitHub Copilot Chat integration.",
       "author": {
         "name": "Rutger Dijkstra",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "envoy",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Plugin-safe Claude Code distribution of Envoy professional development workflows with 25 skills, 25 stack profiles, and self-learning hooks.",
   "author": {
     "name": "Rutger Dijkstra",

--- a/commands/fix-ci.md
+++ b/commands/fix-ci.md
@@ -1,0 +1,7 @@
+---
+description: Auto-diagnose and fix CI/CD failures on a PR
+---
+
+Use the `envoy:fix-ci` skill exactly as written.
+
+Pass any arguments provided by the user to the skill.

--- a/commands/fix-ci.md
+++ b/commands/fix-ci.md
@@ -1,4 +1,5 @@
 ---
+name: fix-ci
 description: Auto-diagnose and fix CI/CD failures on a PR
 ---
 

--- a/docs/plans/2026-04-04-auto-fix-ci.md
+++ b/docs/plans/2026-04-04-auto-fix-ci.md
@@ -1,0 +1,176 @@
+# Auto-Fix CI/CD Failures & Updated CodeRabbit Polling
+
+> **For Claude:** Use envoy:executing-plans to implement this spec task-by-task.
+
+## Overview
+
+Extend Envoy's finalize workflow to automatically detect and fix CI/CD failures (tests, build, lint) after PR creation. Add a standalone `fix-ci` skill for independent use. Update CodeRabbit polling to use exponential backoff with a 20-minute maximum wait time.
+
+## Architecture
+
+Three components:
+
+1. **New `fix-ci` skill** — Core CI diagnosis/fix logic. Polls GitHub Actions, parses failed logs, applies fixes, verifies locally, pushes. Max 3 fix cycles before escalation. Usable standalone or called from finalize.
+
+2. **Extended finalize flow** — After CodeRabbit resolution, polls GitHub Actions status. If failures detected, invokes fix-ci logic inline. Proceeds to final verification only when CI passes.
+
+3. **Updated CodeRabbit polling** — Replace fixed initial wait with exponential backoff (2min → 4min → 8min → 14min → 22min cumulative). If no comments after 20 minutes, proceed without CodeRabbit.
+
+### CI Failure Classification
+
+| Type | Signal | Action |
+|------|--------|--------|
+| `test-failure` | Failed test names + assertion errors in logs | Read test + source, fix, verify locally |
+| `build-error` | Compiler errors with file:line | Fix compilation at error location |
+| `lint-violation` | Linter rule + file:line | Auto-fix or manual fix |
+| `infra-issue` | Runner unavailable, permissions, timeouts | Escalate immediately to user |
+
+### fix-ci Skill Flow
+
+1. **Identify PR and failed runs** — `gh run list --branch <branch>` + `gh run view <id> --log-failed`
+2. **Classify failures** — Parse logs, categorize as test/build/lint/infra
+3. **Diagnose and fix** — Read failing source, apply targeted fix
+4. **Verify locally** — Run same commands CI uses (test, build, lint)
+5. **Push and re-poll** — Push fixes, wait for new CI run with exponential backoff
+6. **Loop or escalate** — Max 3 fix cycles, then present diagnosis summary
+
+### Updated Finalize Flow
+
+1. Run `envoy:docstrings`
+2. Push branch + create PR
+3. Update wiki docs
+4. **Poll for CodeRabbit (exponential backoff, 20min max)** — *updated*
+5. Address CodeRabbit findings (max 3 cycles) — *existing*
+6. **Poll GitHub Actions status (15min timeout)** — *new*
+7. **If CI failures: fix-ci loop (max 3 cycles)** — *new*
+8. Final verification (local tests, build, lint, zero unresolved conversations)
+9. Wiki sync
+10. Handoff
+
+### CodeRabbit Exponential Backoff
+
+```
+intervals = [2min, 2min, 4min, 6min, 8min]
+cumulative =  2     4     8    14    22 min
+
+For each interval:
+  - Sleep for interval duration
+  - Check for CodeRabbit comments via gh api
+  - If comments found: break and start addressing
+  - If not: report progress, continue to next interval
+  
+If 20min exceeded with no comments:
+  - Log "CodeRabbit did not comment within 20 minutes, proceeding"
+  - Skip to CI checks
+```
+
+### CI Polling (After CodeRabbit)
+
+```
+Poll gh pr checks until all checks resolve (pass or fail):
+  - Exponential backoff: 30s, 60s, 120s, 240s...
+  - Timeout: 15 minutes
+  - If all pass: proceed to final verification
+  - If any fail: invoke fix-ci logic
+```
+
+## Acceptance Criteria
+
+- [ ] New `skills/fix-ci/SKILL.md` skill with full diagnosis/fix/verify loop
+- [ ] New `commands/fix-ci.md` command wrapper
+- [ ] Finalize skill updated with CI polling step after CodeRabbit
+- [ ] CodeRabbit polling updated to exponential backoff (20min max)
+- [ ] Fix-ci uses existing loop safeguards (ENVOY_LOOP_COMPLETE, 3 confirmations)
+- [ ] Max 3 fix cycles before escalation with diagnosis summary
+- [ ] Infrastructure failures escalated immediately (not auto-fixed)
+- [ ] Local verification before every push
+- [ ] Standalone `/envoy:fix-ci <pr-number>` works independently
+- [ ] Progress reporting at each polling interval
+
+---
+
+## Implementation Plan
+
+**Execution Strategy:** `sequential`
+
+Tasks are sequential because later tasks depend on earlier ones (fix-ci skill must exist before finalize can reference it, CodeRabbit polling changes affect finalize flow).
+
+### Task 1: Create fix-ci Skill
+
+**Files:**
+- Create: `skills/fix-ci/SKILL.md`
+
+**Steps:**
+
+1. Create `skills/fix-ci/SKILL.md` with YAML frontmatter (`name`, `description`)
+2. Write the full skill definition covering:
+   - PR identification (from arg, `/tmp/envoy-active-pr.txt`, or current branch)
+   - GitHub Actions polling via `gh run list` and `gh run view --log-failed`
+   - Failure classification (test, build, lint, infra)
+   - Diagnosis and fix flow per failure type
+   - Local verification before push
+   - Loop safeguards integration (ENVOY_LOOP_COMPLETE, 3 confirmations)
+   - Max 3 fix cycles with escalation
+   - Announce at start directive
+   - Integration with Envoy section
+3. Commit: `git commit -m "feat(skills): add fix-ci skill for auto-fixing CI/CD failures"`
+
+### Task 2: Create fix-ci Command Wrapper
+
+**Files:**
+- Create: `commands/fix-ci.md`
+
+**Steps:**
+
+1. Create `commands/fix-ci.md` with YAML frontmatter (`description`)
+2. Command should invoke the `fix-ci` skill, passing through any arguments (PR number)
+3. Commit: `git commit -m "feat(commands): add fix-ci command wrapper"`
+
+### Task 3: Update CodeRabbit Polling in Finalize
+
+**Files:**
+- Modify: `skills/finishing-branch/SKILL.md` (CodeRabbit polling section)
+
+**Steps:**
+
+1. Read current `skills/finishing-branch/SKILL.md`
+2. Find the CodeRabbit polling section (Step 4 area — initial wait + comment checking)
+3. Replace fixed wait time with exponential backoff schedule:
+   - Intervals: 2min, 2min, 4min, 6min, 8min (22min cumulative max, effective 20min cutoff)
+   - Progress reporting at each interval
+   - Graceful skip if 20min exceeded with no comments
+4. Verify the rest of the CodeRabbit fix cycle (Steps 5-8) still flows correctly
+5. Commit: `git commit -m "feat(finalize): update CodeRabbit polling to exponential backoff with 20min max"`
+
+### Task 4: Add CI Polling and Fix Step to Finalize
+
+**Files:**
+- Modify: `skills/finishing-branch/SKILL.md` (add new steps after CodeRabbit)
+
+**Steps:**
+
+1. Read current `skills/finishing-branch/SKILL.md` (post Task 3 changes)
+2. After the CodeRabbit resolution steps, add new steps:
+   - **Poll GitHub Actions**: `gh pr checks $PR --json name,state,conclusion` with exponential backoff (30s, 60s, 120s, 240s) and 15min timeout
+   - **If failures detected**: invoke fix-ci skill logic inline (classify, diagnose, fix, verify, push, re-poll — max 3 cycles)
+   - **If all pass**: proceed to final verification
+   - **On escalation**: present failure summary with workflow names, error excerpts, and attempted fixes
+3. Update the final verification step to confirm CI status as part of the "all clear" check
+4. Update the handoff message to include CI status
+5. Commit: `git commit -m "feat(finalize): add CI/CD failure detection and auto-fix after CodeRabbit"`
+
+### Task 5: Add Brainstorming Skill Entry for fix-ci
+
+**Files:**
+- Modify: `skills/writing-skills/SKILL.md` (if skill registry exists) or relevant registration file
+
+**Steps:**
+
+1. Check if there's a skill registry or if skills are auto-discovered
+2. If manual registration needed: add fix-ci to the registry
+3. Verify `/envoy:fix-ci` is invocable in a test session
+4. Commit: `git commit -m "feat(skills): register fix-ci skill"`
+
+---
+
+*Generated by Envoy*

--- a/docs/wiki/Skills-Reference.md
+++ b/docs/wiki/Skills-Reference.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Envoy includes 24 skills organized by purpose.
+Envoy includes 25 skills organized by purpose.
 
 ## Core Workflow
 
@@ -23,6 +23,7 @@ Envoy includes 24 skills organized by purpose.
 | `envoy:verification` | Before committing or claiming a task is complete |
 | `envoy:requesting-code-review` | Completing tasks or before merging |
 | `envoy:receiving-code-review` | Receiving code review feedback |
+| `envoy:fix-ci` | CI/CD checks fail on a PR — diagnose and fix test, build, or lint failures |
 
 ## Advanced Patterns
 

--- a/skills/finishing-branch/SKILL.md
+++ b/skills/finishing-branch/SKILL.md
@@ -110,16 +110,18 @@ PR_NUMBER=<number>
 # intervals = [2min, 2min, 4min, 6min, 8min]
 # cumulative =  2     4     8    14    22 min
 
+CUMULATIVE=0
 for WAIT in 2 2 4 6 8; do
   sleep ${WAIT}m
+  CUMULATIVE=$((CUMULATIVE + WAIT))
   COMMENTS=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
     --jq '[.[] | select(.user.login == "coderabbitai")] | length')
 
   if [ "$COMMENTS" -gt 0 ]; then
-    echo "CodeRabbit left $COMMENTS comments. Addressing..."
+    echo "CodeRabbit left $COMMENTS comments after ${CUMULATIVE}min. Addressing..."
     break
   fi
-  echo "No CodeRabbit comments yet. Waited ${CUMULATIVE}min, next check in ${WAIT}min..."
+  echo "No CodeRabbit comments yet. ${CUMULATIVE}min elapsed."
 done
 ```
 
@@ -217,18 +219,28 @@ Please review and decide how to proceed.
 After CodeRabbit is resolved, poll GitHub Actions for CI status:
 
 ```bash
-# Poll with exponential backoff (30s, 60s, 120s, 240s — 15min timeout)
-for WAIT in 30 60 120 240; do
+# Poll with exponential backoff — 15min timeout
+# intervals: 30s, 60s, 120s, 240s, 240s, 240s (cumulative: 15.5min)
+ELAPSED=0
+for WAIT in 30 60 120 240 240 240; do
   CHECKS=$(gh pr checks $PR_NUMBER --json name,state,conclusion 2>/dev/null)
   PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED")] | length')
-  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion == "FAILURE")] | length')
 
   if [ "$PENDING" -eq 0 ]; then
     break  # All checks resolved
   fi
-  echo "CI checks still running ($PENDING pending). Next poll in ${WAIT}s..."
+
+  ELAPSED=$((ELAPSED + WAIT))
+  if [ "$ELAPSED" -ge 900 ]; then
+    echo "CI checks still running after 15 minutes. Pending: $PENDING"
+    break
+  fi
+
+  echo "CI checks still running ($PENDING pending, ${ELAPSED}s elapsed). Next poll in ${WAIT}s..."
   sleep $WAIT
 done
+
+FAILED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion == "FAILURE")] | length')
 ```
 
 **If all checks pass:** proceed to final verification (Step 10).
@@ -263,9 +275,9 @@ npm run lint
 curl -sf http://localhost:5000/health && echo "✓ Backend" || echo "✗ Backend"
 curl -sf http://localhost:5173 && echo "✓ Frontend" || echo "✗ Frontend"
 
-# CI status
-gh pr checks $PR_NUMBER --json name,conclusion \
-  --jq '.[] | select(.conclusion != "SUCCESS") | .name + ": " + .conclusion'
+# CI status (exclude pending/queued — only show actual failures)
+gh pr checks $PR_NUMBER --json name,state,conclusion \
+  --jq '.[] | select(.state != "PENDING" and .state != "QUEUED") | select(.conclusion != "SUCCESS") | .name + ": " + .conclusion'
 
 # Zero unresolved PR conversations
 gh api graphql -f query='

--- a/skills/finishing-branch/SKILL.md
+++ b/skills/finishing-branch/SKILL.md
@@ -97,22 +97,39 @@ PREOF
 
 Save the PR number.
 
-### Step 4: Poll for GitHub CodeRabbit Comments
+### Step 4: Poll for GitHub CodeRabbit Comments (Exponential Backoff)
 
-GitHub CodeRabbit App reviews the PR asynchronously. Poll for comments:
+GitHub CodeRabbit App reviews the PR asynchronously. Poll with exponential backoff (20-minute max):
 
 ```bash
 OWNER=$(gh repo view --json owner -q '.owner.login')
 REPO=$(gh repo view --json name -q '.name')
 PR_NUMBER=<number>
 
-# Wait briefly for CodeRabbit to start (usually 1-2 minutes)
-# Then poll for comments
-gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-  --jq '.[] | select(.user.login == "coderabbitai") | {id, path, line, body}'
+# Exponential backoff schedule
+# intervals = [2min, 2min, 4min, 6min, 8min]
+# cumulative =  2     4     8    14    22 min
+
+for WAIT in 2 2 4 6 8; do
+  sleep ${WAIT}m
+  COMMENTS=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
+    --jq '[.[] | select(.user.login == "coderabbitai")] | length')
+
+  if [ "$COMMENTS" -gt 0 ]; then
+    echo "CodeRabbit left $COMMENTS comments. Addressing..."
+    break
+  fi
+  echo "No CodeRabbit comments yet. Waited ${CUMULATIVE}min, next check in ${WAIT}min..."
+done
 ```
 
-If no comments after 3-5 minutes, CodeRabbit may not be installed or the PR is clean. Continue to verification.
+**If 20 minutes pass with no comments:**
+```
+CodeRabbit did not comment within 20 minutes. Proceeding without CodeRabbit.
+(CodeRabbit may not be installed, or the PR is clean.)
+```
+
+Skip to CI checks (Step 9).
 
 ### Step 5: Address All CodeRabbit Findings
 

--- a/skills/finishing-branch/SKILL.md
+++ b/skills/finishing-branch/SKILL.md
@@ -212,7 +212,38 @@ After 3 cycles, these comments remain unresolved:
 Please review and decide how to proceed.
 ```
 
-### Step 9: Final Verification
+### Step 9: Poll CI and Auto-Fix Failures
+
+After CodeRabbit is resolved, poll GitHub Actions for CI status:
+
+```bash
+# Poll with exponential backoff (30s, 60s, 120s, 240s — 15min timeout)
+for WAIT in 30 60 120 240; do
+  CHECKS=$(gh pr checks $PR_NUMBER --json name,state,conclusion 2>/dev/null)
+  PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED")] | length')
+  FAILED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion == "FAILURE")] | length')
+
+  if [ "$PENDING" -eq 0 ]; then
+    break  # All checks resolved
+  fi
+  echo "CI checks still running ($PENDING pending). Next poll in ${WAIT}s..."
+  sleep $WAIT
+done
+```
+
+**If all checks pass:** proceed to final verification (Step 10).
+
+**If any checks fail:** invoke fix-ci logic:
+
+```
+/envoy:fix-ci $PR_NUMBER
+```
+
+This runs the full fix-ci cycle: classify failures, diagnose, fix, verify locally, push, re-poll. Max 3 fix cycles before escalation.
+
+**After fix-ci completes (or escalates):** proceed to final verification.
+
+### Step 10: Final Verification
 
 Run envoy:verification with evidence:
 
@@ -232,6 +263,10 @@ npm run lint
 curl -sf http://localhost:5000/health && echo "✓ Backend" || echo "✗ Backend"
 curl -sf http://localhost:5173 && echo "✓ Frontend" || echo "✗ Frontend"
 
+# CI status
+gh pr checks $PR_NUMBER --json name,conclusion \
+  --jq '.[] | select(.conclusion != "SUCCESS") | .name + ": " + .conclusion'
+
 # Zero unresolved PR conversations
 gh api graphql -f query='
   query {
@@ -248,7 +283,7 @@ gh api graphql -f query='
 
 **All checks must pass with evidence.**
 
-### Step 10: Clear Session State
+### Step 11: Clear Session State
 
 Clean up session state and scratchpad files — the work is shipped:
 
@@ -259,13 +294,13 @@ session.clear();     // Remove .envoy-session.json
 scratchpad.clear();  // Remove .envoy-scratchpad.json (if exists)
 ```
 
-### Step 11: Wiki Sync
+### Step 12: Wiki Sync
 
 ```
 /envoy:wiki-sync
 ```
 
-### Step 12: Report
+### Step 13: Report
 
 ```
 **Branch finalized**
@@ -275,6 +310,8 @@ scratchpad.clear();  // Remove .envoy-scratchpad.json (if exists)
 | Docstrings | ✓ Added |
 | PR | ✓ Created (#<number>) |
 | GitHub CodeRabbit | ✓ <N> comments resolved |
+| CI/CD | ✓ All checks passing |
+| CI fix cycles | <N>/3 used |
 | Verification | ✓ Tests, build, lint, health pass |
 | Unresolved conversations | 0 |
 | Session state | ✓ Cleared |
@@ -284,11 +321,10 @@ scratchpad.clear();  // Remove .envoy-scratchpad.json (if exists)
 **Pull Request:** <URL>
 
 **Next steps:**
-1. Wait for CI to pass
-2. Request human reviewers
-3. Address any human feedback
-4. Merge when approved
-5. `/envoy:cleanup` to remove worktree and branch
+1. Request human reviewers
+2. Address any human feedback
+3. Merge when approved
+4. `/envoy:cleanup` to remove worktree and branch
 ```
 
 ## Error Handling
@@ -328,7 +364,8 @@ Options:
 - [ ] **Preconditions:** Feature branch, clean state, tests pass
 - [ ] **Docstrings:** Public APIs documented
 - [ ] **PR created**
-- [ ] **GitHub CodeRabbit:** All comments addressed, replied to, resolved
-- [ ] **Verification:** Tests, build, lint, health, zero unresolved
+- [ ] **GitHub CodeRabbit:** All comments addressed, replied to, resolved (exponential backoff, 20min max)
+- [ ] **CI/CD:** All checks passing (auto-fixed if needed, max 3 cycles)
+- [ ] **Verification:** Tests, build, lint, health, CI green, zero unresolved
 - [ ] **Session state:** Cleared (.envoy-session.json, .envoy-scratchpad.json)
 - [ ] **Wiki:** Synced

--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: fix-ci
+description: Use when CI/CD checks fail on a PR and you need to diagnose and fix test, build, or lint failures
+---
+
+# Fix CI/CD Failures
+
+## Overview
+
+Auto-diagnose and fix CI/CD failures from GitHub Actions. Polls for failed runs, parses logs, classifies failures, applies targeted fixes, verifies locally, and pushes. Max 3 fix cycles before escalation. Usable standalone or called from finalize.
+
+**Announce at start:** "I'm using envoy:fix-ci to diagnose and fix CI failures."
+
+## Arguments
+
+| Flag | Effect |
+|------|--------|
+| `<pr-number>` | PR to check (default: detect from current branch or `/tmp/envoy-active-pr.txt`) |
+
+## Process
+
+### Step 1: Identify PR and Failed Runs
+
+```bash
+# Detect PR number
+if [ -n "$1" ]; then
+  PR_NUMBER=$1
+elif [ -f /tmp/envoy-active-pr.txt ]; then
+  PR_NUMBER=$(cat /tmp/envoy-active-pr.txt)
+else
+  PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null)
+fi
+
+OWNER=$(gh repo view --json owner -q '.owner.login')
+REPO=$(gh repo view --json name -q '.name')
+BRANCH=$(git branch --show-current)
+
+# Get latest check runs
+gh pr checks $PR_NUMBER --json name,state,conclusion 2>/dev/null
+```
+
+If no PR found, report error and stop.
+
+### Step 2: Poll for Check Completion
+
+Checks may still be running. Poll with exponential backoff:
+
+```
+intervals = [30s, 60s, 120s, 240s]
+timeout = 15 minutes
+
+For each interval:
+  - Query: gh pr checks $PR_NUMBER --json name,state,conclusion
+  - If all checks resolved (pass or fail): break
+  - If still running: report progress, sleep, continue
+  - If timeout: report which checks are still pending
+```
+
+### Step 3: Classify Failures
+
+For each failed check, download the log and classify:
+
+```bash
+# Get failed run IDs
+FAILED_RUNS=$(gh run list --branch $BRANCH --status failure --json databaseId,name -q '.[] | .databaseId')
+
+# For each failed run, get the failed log
+gh run view $RUN_ID --log-failed 2>&1
+```
+
+Classify each failure:
+
+| Type | Signal | Action |
+|------|--------|--------|
+| `test-failure` | Failed test names, assertion errors, `FAIL`, `Expected X but got Y` | Read test + source, fix, verify locally |
+| `build-error` | `error CS`, `error TS`, `Cannot find module`, compilation errors with file:line | Fix compilation at error location |
+| `lint-violation` | ESLint/Prettier errors, `warning`/`error` with rule name + file:line | Auto-fix (`--fix`) or manual fix |
+| `infra-issue` | Runner unavailable, permissions, timeouts, Docker pull failures, OOM | **Escalate immediately** — don't try to fix |
+
+### Step 4: Handle Infrastructure Failures
+
+If ANY failure is classified as `infra-issue`, escalate immediately:
+
+```
+**CI Infrastructure Failure — Cannot Auto-Fix**
+
+| Workflow | Error | Type |
+|----------|-------|------|
+| <name> | <error excerpt> | infra-issue |
+
+This is not a code issue. Possible causes:
+- GitHub Actions runner unavailable
+- Docker image pull failure
+- Permission/secret configuration issue
+- Resource limit (OOM, disk space)
+- Network timeout
+
+Please investigate the CI infrastructure.
+```
+
+**Do not attempt to fix infrastructure issues.** Stop here for these.
+
+### Step 5: Diagnose and Fix Code Failures
+
+For each non-infra failure, in order of severity:
+
+**Test failures:**
+1. Parse test name and assertion error from log
+2. Read the failing test file
+3. Read the source file the test exercises
+4. Understand what changed (check recent commits)
+5. Fix the source code (not the test, unless the test is wrong)
+6. Run the test locally to verify
+
+**Build errors:**
+1. Parse file path and line number from error
+2. Read the file at that location
+3. Fix the compilation error
+4. Run build locally to verify
+
+**Lint violations:**
+1. Try auto-fix first: `npm run lint -- --fix` or `dotnet format`
+2. If auto-fix doesn't resolve: read the file and fix manually
+3. Run lint locally to verify
+
+```bash
+# After each fix
+git add -p
+git commit -m "fix: resolve CI failure — <failure type>: <brief description>"
+```
+
+### Step 6: Verify Locally
+
+Before pushing, run the same checks CI uses:
+
+```bash
+# Run what CI runs (adjust for project)
+dotnet test
+dotnet build
+npm test
+npm run lint
+npm run build
+```
+
+**All local checks must pass before pushing.** If they don't, go back to Step 5.
+
+### Step 7: Push and Re-poll
+
+```bash
+git push
+```
+
+Poll for new CI run results with exponential backoff (same as Step 2).
+
+### Step 8: Loop or Escalate (Max 3 Cycles)
+
+Use the **completion signal protocol** from `lib/loop-safeguards.js`:
+
+```
+CYCLE = 0
+MAX_CYCLES = 3
+COMPLETION_COUNT = 0
+
+while CYCLE < MAX_CYCLES:
+  1. Poll CI checks (Step 2)
+  2. If ALL checks pass:
+     → Output: ENVOY_LOOP_COMPLETE with evidence
+     → COMPLETION_COUNT += 1
+     → If COMPLETION_COUNT >= 3: DONE
+     → Else: re-poll to confirm
+  3. If checks fail:
+     → COMPLETION_COUNT = 0 (reset!)
+     → Classify and fix (Steps 3-6)
+     → Push (Step 7)
+     → CYCLE += 1
+
+if CYCLE >= MAX_CYCLES:
+  → ESCALATE
+```
+
+### Escalation Format
+
+```
+**Escalation: CI fix cycle limit reached**
+
+After 3 fix-and-push cycles, these CI checks still fail:
+
+| Workflow | Failure Type | Error | Attempted Fixes |
+|----------|-------------|-------|-----------------|
+| <name> | test-failure | <excerpt> | Fixed X, Y |
+| <name> | build-error | <excerpt> | Fixed Z |
+
+**What was tried:**
+1. Cycle 1: Fixed <description>
+2. Cycle 2: Fixed <description>
+3. Cycle 3: Fixed <description>
+
+**Possible root cause:** <diagnosis>
+
+Please review and decide how to proceed.
+```
+
+### Step 9: Report Success
+
+```
+**CI Failures Fixed**
+
+| Workflow | Status | Fix |
+|----------|--------|-----|
+| <name> | ✓ Passing | <what was fixed> |
+| <name> | ✓ Passing | <what was fixed> |
+
+Fix cycles used: <N>/3
+Commits: <N> fix commits pushed
+All CI checks passing.
+```
+
+## Error Handling
+
+### No PR Found
+
+```
+**Cannot find PR for current branch.**
+
+Specify PR number: /envoy:fix-ci <pr-number>
+```
+
+### No Failed Checks
+
+```
+**All CI checks are passing.** Nothing to fix.
+```
+
+### Checks Still Running
+
+```
+**CI checks still running after 15-minute timeout.**
+
+Pending checks:
+- <check name> (running for Xmin)
+
+Wait for completion or check GitHub Actions directly:
+gh pr checks <pr-number>
+```
+
+## Integration with Envoy
+
+- Called by `envoy:finishing-branch` after CodeRabbit resolution
+- Uses `envoy:verification` principles (evidence before assertions)
+- Uses `lib/loop-safeguards.js` completion signal protocol
+- Standalone usage: `/envoy:fix-ci <pr-number>`

--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -152,29 +152,41 @@ git push
 
 Poll for new CI run results with exponential backoff (same as Step 2).
 
-### Step 8: Loop or Escalate (Max 3 Cycles)
+### Step 8: Loop or Escalate (Max 3 Fix Cycles)
 
-Use the **completion signal protocol** from `lib/loop-safeguards.js`:
+Two separate counters track different concerns:
+- **FIX_CYCLE** — how many times we've pushed code fixes (max 3)
+- **COMPLETION_COUNT** — consecutive passing confirmations (need 3 per `lib/loop-safeguards.js`)
 
 ```
-CYCLE = 0
-MAX_CYCLES = 3
-COMPLETION_COUNT = 0
+FIX_CYCLE = 0
+MAX_FIX_CYCLES = 3
 
-while CYCLE < MAX_CYCLES:
+# Outer loop: fix failures
+while FIX_CYCLE < MAX_FIX_CYCLES:
   1. Poll CI checks (Step 2)
-  2. If ALL checks pass:
-     → Output: ENVOY_LOOP_COMPLETE with evidence
-     → COMPLETION_COUNT += 1
-     → If COMPLETION_COUNT >= 3: DONE
-     → Else: re-poll to confirm
-  3. If checks fail:
-     → COMPLETION_COUNT = 0 (reset!)
+  2. If checks FAIL:
      → Classify and fix (Steps 3-6)
      → Push (Step 7)
-     → CYCLE += 1
+     → FIX_CYCLE += 1
+     → Continue loop
+  3. If ALL checks PASS:
+     → Enter confirmation phase (below)
+     → Break out of fix loop
 
-if CYCLE >= MAX_CYCLES:
+# Confirmation phase: verify CI is genuinely green
+COMPLETION_COUNT = 0
+while COMPLETION_COUNT < 3:
+  1. Poll CI checks
+  2. If ALL pass:
+     → Output: ENVOY_LOOP_COMPLETE with evidence
+     → COMPLETION_COUNT += 1
+  3. If any FAIL:
+     → COMPLETION_COUNT = 0 (reset!)
+     → Return to fix loop (if FIX_CYCLE < MAX_FIX_CYCLES)
+
+# Escalate if fix cycles exhausted
+if FIX_CYCLE >= MAX_FIX_CYCLES and checks still failing:
   → ESCALATE
 ```
 
@@ -245,7 +257,7 @@ gh pr checks <pr-number>
 
 ## Integration with Envoy
 
-- Called by `envoy:finishing-branch` after CodeRabbit resolution
+- Invoked by `envoy:finishing-branch` as `/envoy:fix-ci $PR_NUMBER` after CodeRabbit resolution
 - Uses `envoy:verification` principles (evidence before assertions)
 - Uses `lib/loop-safeguards.js` completion signal protocol
 - Standalone usage: `/envoy:fix-ci <pr-number>`


### PR DESCRIPTION
## Summary

- New `fix-ci` skill that auto-diagnoses and fixes test, build, and lint failures from GitHub Actions logs
- Extended finalize flow to poll CI status and auto-fix failures after CodeRabbit resolution
- Updated CodeRabbit polling to exponential backoff with 20-minute max wait

## Changes

- **New skill:** `skills/fix-ci/SKILL.md` — polls GitHub Actions, classifies failures (test/build/lint/infra), applies targeted fixes, verifies locally, pushes. Max 3 fix cycles with completion signal protocol. Infrastructure failures escalated immediately.
- **New command:** `commands/fix-ci.md` — standalone `/envoy:fix-ci <pr-number>`
- **Modified:** `skills/finishing-branch/SKILL.md` — CodeRabbit exponential backoff (2/2/4/6/8 min intervals, 20min max), CI polling step (15min timeout), auto-fix invocation
- **Updated:** `docs/wiki/Skills-Reference.md` — added fix-ci to skill list

## Test plan

- [ ] `/envoy:fix-ci <pr>` identifies and classifies CI failures
- [ ] Finalize polls CodeRabbit with exponential backoff
- [ ] Finalize polls CI after CodeRabbit, invokes fix-ci on failure
- [ ] Infrastructure failures escalate immediately
- [ ] Max 3 fix cycles before escalation

## Linked Issue

Closes #8

---

*Created with Envoy*