### PR TITLE
Redesign cost reporter: token-focused with phase inference

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "envoy",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Plugin-safe Claude Code distribution of Envoy professional development workflows with 23 skills, 25 stack profiles, and self-learning hooks.",
   "author": {
     "name": "Rutger Dijkstra",

--- a/commands/costs.md
+++ b/commands/costs.md
@@ -1,5 +1,5 @@
 ---
-description: Show token usage and estimated costs for this project
+description: Show token usage breakdown by activity, model, and branch
 ---
 
 Use the `envoy:costs` skill exactly as written.
@@ -8,3 +8,5 @@ Supported flags:
 - `--days N` - Look back N days (default: 7)
 - `--branch <name>` - Filter to a specific branch
 - `--session` - Show current session only
+- `--all` - Show usage across all projects
+- `--team` - Aggregate team reports from docs/costs/reports/

--- a/docs/plans/2026-04-06-cost-reporter-redesign.md
+++ b/docs/plans/2026-04-06-cost-reporter-redesign.md
@@ -78,8 +78,7 @@ Adds a **BY PROJECT** section at the top. Other sections aggregate across all pr
 **Export (hook):** On session end, `hooks/cost-summary-export.js` writes a minimal JSON summary to `docs/costs/reports/<date>-<username>.json` containing:
 - Activity breakdown (label → token count)
 - Model breakdown (model → token count)
-- Branch breakdown (branch → token count)
-- Session metadata (date, turns, total tokens)
+- Session metadata (date, branch, turns, total tokens)
 
 **Aggregation:** `/envoy:costs --team` reads all JSON files from `docs/costs/reports/`, merges them, and renders the same bar-chart format with an added **BY CONTRIBUTOR** section.
 

--- a/docs/plans/2026-04-06-cost-reporter-redesign.md
+++ b/docs/plans/2026-04-06-cost-reporter-redesign.md
@@ -1,0 +1,369 @@
+# Cost Reporter Redesign
+
+> **For Claude:** Use envoy:executing-plans to implement this spec task-by-task.
+
+## Overview
+
+Redesign the cost reporter to focus on actionable token usage visibility rather than dollar estimates. Replace approximate pricing with token counts and percentages, add phase-inference for unlabeled turns, support cross-project and team-aggregated views, and switch to compact plain-text bar-chart output.
+
+## Architecture
+
+Three scoped changes:
+
+1. **`lib/cost-reporter.js`** — Core rework: remove pricing, add phase inference, bar-chart formatter, cross-project discovery, team aggregation
+2. **`commands/costs.md`** — Update command description and flags
+3. **`hooks/cost-summary-export.js`** — New hook: export session summary JSON on session end
+
+No new dependencies. No changes to `skills/costs/SKILL.md` (it just invokes the command).
+
+### Activity Classification (Two-Tier)
+
+**Tier 1 — Explicit (checked first):**
+- Turn has `Skill` tool call → `skill:<name>`
+- Turn has `Agent` tool call → `agent:<type>`
+
+**Tier 2 — Inferred from tool patterns in a sliding window (5 turns before, 5 after):**
+
+| Condition (tool counts in window) | Label |
+|---|---|
+| Edit + Write > 5 and Bash > 3 | `implementation` |
+| Bash > 5 and Grep > 2 and Edit < 3 | `debugging` |
+| Read > 5 and Edit < 2 and Agent > 0 | `review` |
+| AskUserQuestion > 3 | `interactive` |
+| TaskCreate > 1 or Agent > 1 and Edit < 3 | `planning` |
+| fallback | `other` |
+
+Evaluated top-to-bottom, first match wins. Window smoothing prevents single tool calls from flipping the label.
+
+### Token Counting
+
+All token types (input, output, cache_write, cache_read) summed into one number per turn. No separate columns — simpler to reason about relative cost.
+
+### Output Format
+
+Compact plain-text with 20-char bar charts:
+
+```
+Token Usage — last 7 days (12 sessions)
+
+ BY ACTIVITY
+ skill:finishing-branch  ████████████████░░░░  38.2%  4.8M tokens
+ implementation          ██████████░░░░░░░░░░  24.1%  3.0M tokens
+ skill:review            ██████░░░░░░░░░░░░░░  14.7%  1.8M tokens
+ debugging               ████░░░░░░░░░░░░░░░░   9.3%  1.2M tokens
+ agent:Explore           ███░░░░░░░░░░░░░░░░░   6.1%  768K tokens
+ skill:brainstorm        ██░░░░░░░░░░░░░░░░░░   4.2%  524K tokens
+ planning                █░░░░░░░░░░░░░░░░░░░   2.0%  251K tokens
+ other                   ░░░░░░░░░░░░░░░░░░░░   1.4%  175K tokens
+
+ BY MODEL
+ opus-4-6               █████████████████░░░  83.4%  10.5M tokens
+ sonnet-4-6             ███░░░░░░░░░░░░░░░░░  14.2%   1.8M tokens
+ haiku-4-5              ░░░░░░░░░░░░░░░░░░░░   2.4%   302K tokens
+
+ BY BRANCH
+ feature/14-self-learn  ████████████░░░░░░░░  58.1%   7.3M tokens
+ feature/12-fix-ci      ██████░░░░░░░░░░░░░░  28.3%   3.6M tokens
+ main                   ███░░░░░░░░░░░░░░░░░  13.6%   1.7M tokens
+```
+
+### Cross-Project (`--all`)
+
+Scans all subdirectories under `~/.claude/projects/`. Project name derived from last two segments of the encoded directory name (e.g., `-Users-rutgerdijkstra-Projects-EnvoyProject-envoy` → `EnvoyProject/envoy`).
+
+Adds a **BY PROJECT** section at the top. Other sections aggregate across all projects.
+
+### Team Visibility (`--team`)
+
+**Export (hook):** On session end, `hooks/cost-summary-export.js` writes a minimal JSON summary to `docs/costs/reports/<date>-<username>.json` containing:
+- Activity breakdown (label → token count)
+- Model breakdown (model → token count)
+- Branch breakdown (branch → token count)
+- Session metadata (date, turns, total tokens)
+
+**Aggregation:** `/envoy:costs --team` reads all JSON files from `docs/costs/reports/`, merges them, and renders the same bar-chart format with an added **BY CONTRIBUTOR** section.
+
+**Individual files are committed** to the repo for team transparency. They're small (< 1KB each), contain no prompts or content — just token breakdowns.
+
+## Acceptance Criteria
+
+- [ ] No dollar estimates anywhere in output
+- [ ] Tier 1 (explicit skill/agent) detection works as today
+- [ ] Tier 2 (phase inference) classifies turns using tool-pattern windows
+- [ ] Token counts summed as single number (input + output + cache combined)
+- [ ] Bar-chart plain-text output, sorted by token count descending
+- [ ] `--all` flag discovers all projects and adds BY PROJECT section
+- [ ] `--team` flag aggregates from committed JSON files in `docs/costs/reports/`
+- [ ] `--days N` and `--branch` filters still work
+- [ ] Session-end hook exports summary JSON to `docs/costs/reports/`
+- [ ] Existing `formatTokens()` reused for human-readable numbers
+
+---
+
+## Implementation Plan
+
+**Execution Strategy:** `sequential`
+
+Tasks are tightly coupled — the formatter depends on the new data shape, the hook depends on the new export format, and the command depends on all of them.
+
+### Task 1: Strip Dollar Pricing and Rework Token Aggregation
+
+**Files:**
+- Modify: `lib/cost-reporter.js`
+- Create: `tests/lib/cost-reporter.test.js`
+
+**Step 1: Write failing test**
+
+```javascript
+const { extractSessionUsage } = require('../../lib/cost-reporter');
+// Test that usage returns combined token count, no costUSD
+test('extractSessionUsage returns totalTokens, no costUSD', () => {
+  const usage = extractSessionUsage('/tmp/test-session.jsonl');
+  expect(usage).toHaveProperty('totalTokens');
+  expect(usage).not.toHaveProperty('estimatedCostUSD');
+});
+```
+
+**Step 2: Run test (expect FAIL)**
+
+**Step 3: Implement**
+
+- Remove `PRICING` constant, `calculateCost()`, `findPricing()`
+- Remove all `costUSD` and `estimatedCostUSD` fields from aggregation
+- Add `totalTokens` field: `input_tokens + output_tokens + cache_creation_input_tokens + cache_read_input_tokens`
+- Update `getRecentUsage()` to aggregate `totalTokens` instead of `costUSD`
+- Sort all breakdowns by `totalTokens` descending (was `costUSD`)
+
+**Step 4: Run test (expect PASS)**
+
+**Step 5: Commit**
+
+```bash
+git add lib/cost-reporter.js tests/lib/cost-reporter.test.js
+git commit -m "refactor(costs): strip dollar pricing, use combined token counts"
+```
+
+### Task 2: Add Phase Inference to Activity Detection
+
+**Files:**
+- Modify: `lib/cost-reporter.js`
+- Modify: `tests/lib/cost-reporter.test.js`
+
+**Step 1: Write failing test**
+
+```javascript
+test('classifyPhase detects implementation from tool window', () => {
+  const window = [
+    { tools: ['Edit', 'Edit', 'Bash', 'Write', 'Edit', 'Bash', 'Edit', 'Bash', 'Edit'] },
+  ];
+  expect(classifyPhase(window)).toBe('implementation');
+});
+
+test('classifyPhase detects debugging from grep-heavy window', () => {
+  const window = [
+    { tools: ['Bash', 'Bash', 'Grep', 'Read', 'Bash', 'Grep', 'Bash', 'Grep'] },
+  ];
+  expect(classifyPhase(window)).toBe('debugging');
+});
+```
+
+**Step 2: Run test (expect FAIL)**
+
+**Step 3: Implement**
+
+- Add `classifyPhase(toolWindow)` function with the decision tree:
+  - Edit + Write > 5 and Bash > 3 → `implementation`
+  - Bash > 5 and Grep > 2 and Edit < 3 → `debugging`
+  - Read > 5 and Edit < 2 and Agent > 0 → `review`
+  - AskUserQuestion > 3 → `interactive`
+  - TaskCreate > 1 or (Agent > 1 and Edit < 3) → `planning`
+  - fallback → `other`
+- Modify `extractSessionUsage()` to:
+  1. First pass: collect all turns with their tool names
+  2. Second pass: for each turn, build a window (5 before, 5 after), apply Tier 1 then Tier 2 classification
+- Export `classifyPhase` for testing
+
+**Step 4: Run test (expect PASS)**
+
+**Step 5: Commit**
+
+```bash
+git add lib/cost-reporter.js tests/lib/cost-reporter.test.js
+git commit -m "feat(costs): add phase inference for unlabeled turns"
+```
+
+### Task 3: Replace Report Formatter with Bar-Chart Output
+
+**Files:**
+- Modify: `lib/cost-reporter.js`
+- Modify: `tests/lib/cost-reporter.test.js`
+
+**Step 1: Write failing test**
+
+```javascript
+test('formatReport produces bar-chart output with no dollar signs', () => {
+  const report = formatReport(mockData);
+  expect(report).toContain('BY ACTIVITY');
+  expect(report).toContain('████');
+  expect(report).toContain('%');
+  expect(report).not.toContain('$');
+});
+```
+
+**Step 2: Run test (expect FAIL)**
+
+**Step 3: Implement**
+
+- Replace `formatReport()` entirely
+- Add `renderBar(fraction, width=20)` helper using `█` (filled) and `░` (empty)
+- Add `renderSection(title, entries)` that produces aligned rows:
+  - Left-pad labels to longest label width
+  - Bar + percentage + formatted token count
+- Sections: BY ACTIVITY, BY MODEL, BY BRANCH
+- Header line: `Token Usage — last {N} days ({M} sessions)`
+
+**Step 4: Run test (expect PASS)**
+
+**Step 5: Commit**
+
+```bash
+git add lib/cost-reporter.js tests/lib/cost-reporter.test.js
+git commit -m "feat(costs): bar-chart plain-text output format"
+```
+
+### Task 4: Add Cross-Project Discovery (`--all`)
+
+**Files:**
+- Modify: `lib/cost-reporter.js`
+- Modify: `tests/lib/cost-reporter.test.js`
+
+**Step 1: Write failing test**
+
+```javascript
+test('decodeProjectName extracts last two path segments', () => {
+  expect(decodeProjectName('-Users-rutger-Projects-EnvoyProject-envoy'))
+    .toBe('EnvoyProject/envoy');
+});
+
+test('discoverAllProjects returns array of project dirs', () => {
+  const projects = discoverAllProjects();
+  expect(Array.isArray(projects)).toBe(true);
+});
+```
+
+**Step 2: Run test (expect FAIL)**
+
+**Step 3: Implement**
+
+- Add `decodeProjectName(encodedDir)` — splits on `-`, takes last two meaningful segments
+- Add `discoverAllProjects()` — scans `~/.claude/projects/`, returns array of `{ name, projectDir }`
+- Modify `getRecentUsage()` to accept `options.all` flag
+  - When true: iterate all project dirs, aggregate with a `byProject` breakdown
+- Add BY PROJECT section to `formatReport()` when `byProject` data exists
+
+**Step 4: Run test (expect PASS)**
+
+**Step 5: Commit**
+
+```bash
+git add lib/cost-reporter.js tests/lib/cost-reporter.test.js
+git commit -m "feat(costs): cross-project discovery with --all flag"
+```
+
+### Task 5: Add Team Export Hook
+
+**Files:**
+- Create: `hooks/cost-summary-export.js`
+- Modify: `hooks/hooks.json`
+- Create: `tests/hooks/cost-summary-export.test.js`
+
+**Step 1: Write failing test**
+
+```javascript
+test('buildSummaryJson produces valid team-export JSON', () => {
+  const summary = buildSummaryJson(mockSessionUsage, 'rutger', 'main');
+  expect(summary).toHaveProperty('date');
+  expect(summary).toHaveProperty('user', 'rutger');
+  expect(summary).toHaveProperty('activities');
+  expect(summary).toHaveProperty('models');
+  expect(summary).toHaveProperty('totalTokens');
+  expect(summary).not.toHaveProperty('costUSD');
+});
+```
+
+**Step 2: Run test (expect FAIL)**
+
+**Step 3: Implement**
+
+- `hooks/cost-summary-export.js`:
+  - Export `run(rawInput)` function (standard hook interface)
+  - On session end: extract usage for current session
+  - Build minimal JSON: `{ date, user, branch, totalTokens, turns, activities: {label: tokens}, models: {model: tokens}, branches: {branch: tokens} }`
+  - Write to `docs/costs/reports/<YYYY-MM-DD>-<username>.json`
+  - Get username from `os.userInfo().username`
+- Register in `hooks/hooks.json` with event `session_end`, profile `standard`
+
+**Step 4: Run test (expect PASS)**
+
+**Step 5: Commit**
+
+```bash
+git add hooks/cost-summary-export.js hooks/hooks.json tests/hooks/cost-summary-export.test.js
+git commit -m "feat(costs): session-end hook exports team summary JSON"
+```
+
+### Task 6: Add Team Aggregation (`--team`)
+
+**Files:**
+- Modify: `lib/cost-reporter.js`
+- Modify: `tests/lib/cost-reporter.test.js`
+
+**Step 1: Write failing test**
+
+```javascript
+test('aggregateTeamReports merges multiple JSON files', () => {
+  const result = aggregateTeamReports('/tmp/test-costs/reports');
+  expect(result.byContributor).toBeDefined();
+  expect(Object.keys(result.byContributor).length).toBeGreaterThan(0);
+});
+```
+
+**Step 2: Run test (expect FAIL)**
+
+**Step 3: Implement**
+
+- Add `aggregateTeamReports(reportsDir, options)`:
+  - Scan `docs/costs/reports/*.json`
+  - Filter by `--days` and `--branch` if provided
+  - Merge into same structure as `getRecentUsage` output, with added `byContributor` breakdown
+- Add BY CONTRIBUTOR section to `formatReport()` when `byContributor` data exists
+- Wire `--team` flag through command
+
+**Step 4: Run test (expect PASS)**
+
+**Step 5: Commit**
+
+```bash
+git add lib/cost-reporter.js tests/lib/cost-reporter.test.js
+git commit -m "feat(costs): team aggregation from committed JSON reports"
+```
+
+### Task 7: Update Command Definition
+
+**Files:**
+- Modify: `commands/costs.md`
+
+**Steps:**
+1. Update description to reflect token-focused purpose
+2. Add `--all` and `--team` flags to usage
+3. Remove any references to dollar estimates
+4. Commit:
+
+```bash
+git add commands/costs.md
+git commit -m "docs(costs): update command for token-focused redesign"
+```
+
+---
+
+*Generated by Envoy*

--- a/docs/plans/2026-04-06-cost-reporter-redesign.md
+++ b/docs/plans/2026-04-06-cost-reporter-redesign.md
@@ -75,7 +75,7 @@ Adds a **BY PROJECT** section at the top. Other sections aggregate across all pr
 
 ### Team Visibility (`--team`)
 
-**Export (hook):** On session end, `hooks/cost-summary-export.js` writes a minimal JSON summary to `docs/costs/reports/<date>-<username>.json` containing:
+**Export (hook):** On session end, `hooks/cost-summary-export.js` writes a minimal JSON summary to `docs/costs/reports/<date>-<username>-<HHMMSS>.json` containing:
 - Activity breakdown (label → token count)
 - Model breakdown (model → token count)
 - Session metadata (date, branch, turns, total tokens)

--- a/docs/plans/2026-04-06-cost-reporter-redesign.md
+++ b/docs/plans/2026-04-06-cost-reporter-redesign.md
@@ -14,7 +14,7 @@ Three scoped changes:
 2. **`commands/costs.md`** — Update command description and flags
 3. **`hooks/cost-summary-export.js`** — New hook: export session summary JSON on session end
 
-No new dependencies. No changes to `skills/costs/SKILL.md` (it just invokes the command).
+No new dependencies.
 
 ### Activity Classification (Two-Tier)
 

--- a/hooks/cost-summary-export.js
+++ b/hooks/cost-summary-export.js
@@ -12,13 +12,16 @@ const os = require('os');
 
 /**
  * Build the export path for a cost summary.
+ * Includes timestamp to avoid overwriting earlier sessions on the same day.
  * @param {string} projectRoot
  * @param {string} username
+ * @param {Date} now
  * @returns {string}
  */
-function getExportPath(projectRoot, username) {
-  const date = new Date().toISOString().split('T')[0];
-  return path.join(projectRoot, 'docs', 'costs', 'reports', `${date}-${username}.json`);
+function getExportPath(projectRoot, username, now) {
+  const date = now.toISOString().split('T')[0];
+  const time = now.toISOString().split('T')[1].replace(/[:.]/g, '').slice(0, 6);
+  return path.join(projectRoot, 'docs', 'costs', 'reports', `${date}-${username}-${time}.json`);
 }
 
 /**
@@ -26,9 +29,10 @@ function getExportPath(projectRoot, username) {
  * @param {import('../lib/cost-reporter').SessionUsage} usage
  * @param {string} username
  * @param {string} branch
+ * @param {Date} now
  * @returns {object}
  */
-function buildSummaryJson(usage, username, branch) {
+function buildSummaryJson(usage, username, branch, now) {
   const activities = {};
   for (const [label, a] of Object.entries(usage.activities || {})) {
     activities[label] = a.totalTokens;
@@ -40,7 +44,7 @@ function buildSummaryJson(usage, username, branch) {
   }
 
   return {
-    date: new Date().toISOString().split('T')[0],
+    date: now.toISOString().split('T')[0],
     user: username,
     branch,
     totalTokens: usage.totalTokens,
@@ -72,13 +76,14 @@ function run(rawInput) {
     if (usage.turns === 0) return;
 
     const username = os.userInfo().username;
-    const exportPath = getExportPath(process.cwd(), username);
+    const now = new Date();
+    const exportPath = getExportPath(process.cwd(), username, now);
 
     // Ensure directory exists
     const dir = path.dirname(exportPath);
     fs.mkdirSync(dir, { recursive: true });
 
-    const summary = buildSummaryJson(usage, username, latest.gitBranch || 'unknown');
+    const summary = buildSummaryJson(usage, username, latest.gitBranch || 'unknown', now);
     fs.writeFileSync(exportPath, JSON.stringify(summary, null, 2) + '\n');
   } catch {
     // Async hook — never block or pollute context

--- a/hooks/cost-summary-export.js
+++ b/hooks/cost-summary-export.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Async Stop hook: Export session token usage summary to a committable JSON file.
+ *
+ * Writes a minimal JSON summary to docs/costs/reports/<date>-<username>.json
+ * for team visibility. Contains only token breakdowns — no prompts or content.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+/**
+ * Build the export path for a cost summary.
+ * @param {string} projectRoot
+ * @param {string} username
+ * @returns {string}
+ */
+function getExportPath(projectRoot, username) {
+  const date = new Date().toISOString().split('T')[0];
+  return path.join(projectRoot, 'docs', 'costs', 'reports', `${date}-${username}.json`);
+}
+
+/**
+ * Build a minimal JSON summary from session usage data.
+ * @param {import('../lib/cost-reporter').SessionUsage} usage
+ * @param {string} username
+ * @param {string} branch
+ * @returns {object}
+ */
+function buildSummaryJson(usage, username, branch) {
+  const activities = {};
+  for (const [label, a] of Object.entries(usage.activities || {})) {
+    activities[label] = a.totalTokens;
+  }
+
+  const models = {};
+  for (const [model, m] of Object.entries(usage.models || {})) {
+    models[model] = m.totalTokens;
+  }
+
+  return {
+    date: new Date().toISOString().split('T')[0],
+    user: username,
+    branch,
+    totalTokens: usage.totalTokens,
+    turns: usage.turns,
+    activities,
+    models,
+  };
+}
+
+/**
+ * Hook entry point. Called by hook-runner on Stop event.
+ * @param {string} rawInput
+ */
+function run(rawInput) {
+  try {
+    const costReporter = require('../lib/cost-reporter');
+    const projectDir = costReporter.findProjectDir(process.cwd());
+    if (!projectDir) return;
+
+    // Find the most recent session
+    const sessions = costReporter.discoverSessions(projectDir);
+    if (sessions.length === 0) return;
+
+    // Sort by modified date, take the most recent
+    sessions.sort((a, b) => new Date(b.modified) - new Date(a.modified));
+    const latest = sessions[0];
+
+    const usage = costReporter.extractSessionUsage(latest.jsonlPath);
+    if (usage.turns === 0) return;
+
+    const username = os.userInfo().username;
+    const exportPath = getExportPath(process.cwd(), username);
+
+    // Ensure directory exists
+    const dir = path.dirname(exportPath);
+    fs.mkdirSync(dir, { recursive: true });
+
+    const summary = buildSummaryJson(usage, username, latest.gitBranch || 'unknown');
+    fs.writeFileSync(exportPath, JSON.stringify(summary, null, 2) + '\n');
+  } catch {
+    // Async hook — never block or pollute context
+  }
+}
+
+module.exports = { run, buildSummaryJson, getExportPath };

--- a/hooks/hook-runner.js
+++ b/hooks/hook-runner.js
@@ -29,6 +29,7 @@ const HOOK_PROFILES = {
   'post-pr-poll':           ['standard', 'strict'],
   'coderabbit-aggregator':  ['standard', 'strict'],
   'correction-detector':    ['standard', 'strict'],
+  'cost-summary-export':    ['standard', 'strict'],
 };
 
 /**

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -78,6 +78,12 @@
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.js\" coderabbit-aggregator",
             "_profiles": ["standard", "strict"],
             "_async": true
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.js\" cost-summary-export",
+            "_profiles": ["standard", "strict"],
+            "_async": true
           }
         ]
       }

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -641,6 +641,71 @@ function discoverAllProjects() {
   }
 }
 
+/**
+ * Get aggregated usage across all Claude projects.
+ * @param {Object} [options]
+ * @param {number} [options.days=7]
+ * @returns {AggregatedUsage}
+ */
+function getAllProjectsUsage(options = {}) {
+  const days = options.days || 7;
+  const projects = discoverAllProjects();
+
+  const result = {
+    period: `${days} days`,
+    sessions: [],
+    totals: { totalTokens: 0, turns: 0 },
+    byProject: {},
+    byBranch: {},
+    byModel: {},
+    byActivity: {},
+  };
+
+  for (const project of projects) {
+    const projectUsage = getRecentUsage(project.projectDir, { days });
+
+    if (projectUsage.totals.totalTokens === 0) continue;
+
+    // Merge sessions
+    for (const s of projectUsage.sessions) {
+      result.sessions.push(s);
+    }
+
+    // Accumulate totals
+    result.totals.totalTokens += projectUsage.totals.totalTokens;
+    result.totals.turns += projectUsage.totals.turns;
+
+    // By project
+    result.byProject[project.name] = { totalTokens: projectUsage.totals.totalTokens };
+
+    // Merge byModel
+    for (const [model, m] of Object.entries(projectUsage.byModel)) {
+      if (!result.byModel[model]) result.byModel[model] = { turns: 0, totalTokens: 0 };
+      result.byModel[model].turns += m.turns;
+      result.byModel[model].totalTokens += m.totalTokens;
+    }
+
+    // Merge byActivity
+    for (const [activity, a] of Object.entries(projectUsage.byActivity)) {
+      if (!result.byActivity[activity]) result.byActivity[activity] = { turns: 0, totalTokens: 0, models: {} };
+      result.byActivity[activity].turns += a.turns;
+      result.byActivity[activity].totalTokens += a.totalTokens;
+      for (const [model, count] of Object.entries(a.models || {})) {
+        result.byActivity[activity].models[model] = (result.byActivity[activity].models[model] || 0) + count;
+      }
+    }
+
+    // Merge byBranch
+    for (const [branch, b] of Object.entries(projectUsage.byBranch)) {
+      if (!result.byBranch[branch]) result.byBranch[branch] = { sessions: 0, totalTokens: 0 };
+      result.byBranch[branch].sessions += b.sessions;
+      result.byBranch[branch].totalTokens += b.totalTokens;
+    }
+  }
+
+  return result;
+}
+
 module.exports = {
   findProjectDir,
   loadSessionsIndex,
@@ -655,6 +720,7 @@ module.exports = {
   discoverSessions,
   decodeProjectName,
   discoverAllProjects,
+  getAllProjectsUsage,
   aggregateTeamReports,
 };
 

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -509,11 +509,15 @@ function formatReport(data) {
  * @returns {{totals: {totalTokens: number, turns: number}, byContributor: Object, byActivity: Object, byModel: Object}}
  */
 function aggregateTeamReports(reportsDir, options = {}) {
+  const days = options.days || null;
   const result = {
+    period: days ? `${days} days` : 'all time',
+    sessions: [],
     totals: { totalTokens: 0, turns: 0 },
     byContributor: {},
     byActivity: {},
     byModel: {},
+    byBranch: {},
   };
 
   let files;
@@ -569,6 +573,14 @@ function aggregateTeamReports(reportsDir, options = {}) {
       }
       result.byModel[model].totalTokens += modelTokens;
     }
+
+    // By branch
+    const br = report.branch || 'unknown';
+    if (!result.byBranch[br]) {
+      result.byBranch[br] = { sessions: 0, totalTokens: 0 };
+    }
+    result.byBranch[br].sessions += 1;
+    result.byBranch[br].totalTokens += tokens;
   }
 
   return result;

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -54,11 +54,12 @@ function loadSessionsIndex(projectDir) {
 }
 
 /**
- * Detect the Envoy activity from an assistant message's content.
+ * Detect an explicit Envoy activity from an assistant message's content.
  * Only inspects actual tool_use blocks (not text, not Edit new_string fields).
+ * Returns null when no explicit label is found — the caller applies phase inference.
  *
  * @param {object} msg - The assistant message object
- * @returns {string} Activity label (e.g., "skill:finalize", "agent:Explore", "general")
+ * @returns {string|null} Activity label (e.g., "skill:finalize", "agent:Explore", "review") or null
  */
 function detectActivity(msg) {
   const blocks = Array.isArray(msg.content) ? msg.content : [];
@@ -549,6 +550,7 @@ function aggregateTeamReports(reportsDir, options = {}) {
 
     result.totals.totalTokens += tokens;
     result.totals.turns += turns;
+    result.sessions.push({ date: report.date, user: report.user, branch: report.branch, totalTokens: tokens, turns });
 
     // By contributor
     const user = report.user || 'unknown';

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -576,14 +576,33 @@ function aggregateTeamReports(reportsDir, options = {}) {
 
 /**
  * Decode a Claude projects directory name into a human-readable project name.
- * Takes the last two meaningful path segments.
+ *
+ * Claude encodes paths by replacing '/' with '-', which is lossy — hyphens
+ * in directory names become indistinguishable from path separators.
+ * We try to reconstruct by matching against the actual filesystem path.
+ * Falls back to last two dash-separated segments if no match found.
+ *
  * e.g., "-Users-rutger-Projects-EnvoyProject-envoy" → "EnvoyProject/envoy"
  *
  * @param {string} encodedDir
  * @returns {string}
  */
 function decodeProjectName(encodedDir) {
-  // Split on '-', filter empty strings (leading dash produces empty first element)
+  // Try to reconstruct original path and check if it exists
+  const candidate = encodedDir.replace(/^-/, '').replace(/-/g, '/');
+  const fullPath = '/' + candidate;
+
+  // Walk backwards through the path to find the deepest existing directory
+  // then take the last two real path segments
+  const parts = fullPath.split('/').filter(Boolean);
+  for (let i = parts.length; i >= 2; i--) {
+    const testPath = '/' + parts.slice(0, i).join('/');
+    if (fs.existsSync(testPath)) {
+      return parts.slice(i - 2, i).join('/');
+    }
+  }
+
+  // Fallback: last two dash-separated segments
   const segments = encodedDir.split('-').filter(Boolean);
   if (segments.length < 2) return segments.join('/');
   return segments.slice(-2).join('/');

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -13,14 +13,14 @@ const path = require('path');
 const os = require('os');
 
 /**
- * Approximate cost per token by model (USD).
- * Pricing as of 2025. Update as needed.
+ * Sum all token types into a single count.
+ * @param {{input_tokens?: number, output_tokens?: number, cache_creation_input_tokens?: number, cache_read_input_tokens?: number}} u
+ * @returns {number}
  */
-const PRICING = {
-  'claude-opus-4-6': { input: 15 / 1_000_000, output: 75 / 1_000_000, cacheWrite: 18.75 / 1_000_000, cacheRead: 1.5 / 1_000_000 },
-  'claude-sonnet-4-6': { input: 3 / 1_000_000, output: 15 / 1_000_000, cacheWrite: 3.75 / 1_000_000, cacheRead: 0.3 / 1_000_000 },
-  'claude-haiku-4-5': { input: 0.8 / 1_000_000, output: 4 / 1_000_000, cacheWrite: 1 / 1_000_000, cacheRead: 0.08 / 1_000_000 },
-};
+function sumTokens(u) {
+  return (u.input_tokens || 0) + (u.output_tokens || 0) +
+    (u.cache_creation_input_tokens || 0) + (u.cache_read_input_tokens || 0);
+}
 
 /**
  * Find the Claude project directory for a given working directory.
@@ -94,23 +94,6 @@ function detectActivity(msg) {
 }
 
 /**
- * Calculate cost for a set of token counts and a model.
- * @param {{input_tokens?: number, output_tokens?: number, cache_creation_input_tokens?: number, cache_read_input_tokens?: number}} u
- * @param {string} model
- * @returns {number} Estimated cost in USD
- */
-function calculateCost(u, model) {
-  const pricing = findPricing(model);
-  if (!pricing) return 0;
-  return (
-    (u.input_tokens || 0) * pricing.input +
-    (u.output_tokens || 0) * pricing.output +
-    (u.cache_creation_input_tokens || 0) * pricing.cacheWrite +
-    (u.cache_read_input_tokens || 0) * pricing.cacheRead
-  );
-}
-
-/**
  * Extract token usage from a session JSONL file.
  * Tracks usage per model AND per Envoy activity (skill, agent, hook).
  *
@@ -119,14 +102,10 @@ function calculateCost(u, model) {
  */
 function extractSessionUsage(jsonlPath) {
   const usage = {
-    inputTokens: 0,
-    outputTokens: 0,
-    cacheWriteTokens: 0,
-    cacheReadTokens: 0,
+    totalTokens: 0,
     turns: 0,
     models: {},
     activities: {},
-    estimatedCostUSD: 0,
   };
 
   try {
@@ -149,38 +128,26 @@ function extractSessionUsage(jsonlPath) {
       const u = msg.usage;
       const model = msg.model || 'unknown';
       const activity = detectActivity(msg);
-      const turnCost = calculateCost(u, model);
+      const turnTokens = sumTokens(u);
 
-      usage.inputTokens += u.input_tokens || 0;
-      usage.outputTokens += u.output_tokens || 0;
-      usage.cacheWriteTokens += u.cache_creation_input_tokens || 0;
-      usage.cacheReadTokens += u.cache_read_input_tokens || 0;
+      usage.totalTokens += turnTokens;
       usage.turns += 1;
-      usage.estimatedCostUSD += turnCost;
 
       // Track per-model
       if (!usage.models[model]) {
-        usage.models[model] = { input: 0, output: 0, cacheWrite: 0, cacheRead: 0, turns: 0, costUSD: 0 };
+        usage.models[model] = { totalTokens: 0, turns: 0 };
       }
       const m = usage.models[model];
-      m.input += u.input_tokens || 0;
-      m.output += u.output_tokens || 0;
-      m.cacheWrite += u.cache_creation_input_tokens || 0;
-      m.cacheRead += u.cache_read_input_tokens || 0;
+      m.totalTokens += turnTokens;
       m.turns += 1;
-      m.costUSD += turnCost;
 
       // Track per-activity
       if (!usage.activities[activity]) {
-        usage.activities[activity] = { turns: 0, input: 0, output: 0, cacheWrite: 0, cacheRead: 0, costUSD: 0, models: {} };
+        usage.activities[activity] = { turns: 0, totalTokens: 0, models: {} };
       }
       const a = usage.activities[activity];
       a.turns += 1;
-      a.input += u.input_tokens || 0;
-      a.output += u.output_tokens || 0;
-      a.cacheWrite += u.cache_creation_input_tokens || 0;
-      a.cacheRead += u.cache_read_input_tokens || 0;
-      a.costUSD += turnCost;
+      a.totalTokens += turnTokens;
 
       // Track model within activity
       if (!a.models[model]) a.models[model] = 0;
@@ -191,22 +158,6 @@ function extractSessionUsage(jsonlPath) {
   }
 
   return usage;
-}
-
-/**
- * Find pricing for a model, matching by prefix.
- * @param {string} model
- * @returns {typeof PRICING[keyof typeof PRICING] | null}
- */
-function findPricing(model) {
-  for (const [key, pricing] of Object.entries(PRICING)) {
-    if (model.startsWith(key) || model.includes(key)) return pricing;
-  }
-  // Fallback heuristics
-  if (model.includes('opus')) return PRICING['claude-opus-4-6'];
-  if (model.includes('sonnet')) return PRICING['claude-sonnet-4-6'];
-  if (model.includes('haiku')) return PRICING['claude-haiku-4-5'];
-  return null;
 }
 
 /**
@@ -312,12 +263,8 @@ function getRecentUsage(projectDir, options = {}) {
     period: `${days} days`,
     sessions: [],
     totals: {
-      inputTokens: 0,
-      outputTokens: 0,
-      cacheWriteTokens: 0,
-      cacheReadTokens: 0,
+      totalTokens: 0,
       turns: 0,
-      estimatedCostUSD: 0,
     },
     byBranch: {},
     byModel: {},
@@ -342,43 +289,34 @@ function getRecentUsage(projectDir, options = {}) {
     });
 
     // Accumulate totals
-    result.totals.inputTokens += usage.inputTokens;
-    result.totals.outputTokens += usage.outputTokens;
-    result.totals.cacheWriteTokens += usage.cacheWriteTokens;
-    result.totals.cacheReadTokens += usage.cacheReadTokens;
+    result.totals.totalTokens += usage.totalTokens;
     result.totals.turns += usage.turns;
-    result.totals.estimatedCostUSD += usage.estimatedCostUSD;
 
     // By branch
     const br = session.gitBranch || 'unknown';
     if (!result.byBranch[br]) {
-      result.byBranch[br] = { sessions: 0, tokens: 0, costUSD: 0 };
+      result.byBranch[br] = { sessions: 0, totalTokens: 0 };
     }
     result.byBranch[br].sessions += 1;
-    result.byBranch[br].tokens += usage.inputTokens + usage.outputTokens;
-    result.byBranch[br].costUSD += usage.estimatedCostUSD;
+    result.byBranch[br].totalTokens += usage.totalTokens;
 
     // By model
     for (const [model, modelUsage] of Object.entries(usage.models)) {
       if (!result.byModel[model]) {
-        result.byModel[model] = { turns: 0, input: 0, output: 0, costUSD: 0 };
+        result.byModel[model] = { turns: 0, totalTokens: 0 };
       }
       result.byModel[model].turns += modelUsage.turns;
-      result.byModel[model].input += modelUsage.input;
-      result.byModel[model].output += modelUsage.output;
-      result.byModel[model].costUSD += modelUsage.costUSD;
+      result.byModel[model].totalTokens += modelUsage.totalTokens;
     }
 
     // By activity
     for (const [activity, actUsage] of Object.entries(usage.activities)) {
       if (!result.byActivity[activity]) {
-        result.byActivity[activity] = { turns: 0, input: 0, output: 0, costUSD: 0, models: {} };
+        result.byActivity[activity] = { turns: 0, totalTokens: 0, models: {} };
       }
       const a = result.byActivity[activity];
       a.turns += actUsage.turns;
-      a.input += actUsage.input;
-      a.output += actUsage.output;
-      a.costUSD += actUsage.costUSD;
+      a.totalTokens += actUsage.totalTokens;
 
       for (const [model, count] of Object.entries(actUsage.models)) {
         a.models[model] = (a.models[model] || 0) + count;
@@ -401,101 +339,14 @@ function formatTokens(n) {
 }
 
 /**
- * Format cost for display.
- * @param {number} usd
- * @returns {string}
- */
-function formatCost(usd) {
-  if (usd >= 1) return '$' + usd.toFixed(2);
-  if (usd >= 0.01) return '$' + usd.toFixed(2);
-  return '$' + usd.toFixed(4);
-}
-
-/**
- * Format aggregated usage as a readable report.
+ * Format aggregated usage as a readable report (placeholder — replaced in Task 3).
  * @param {AggregatedUsage} data
  * @returns {string}
  */
 function formatReport(data) {
   const lines = [];
-
-  lines.push(`## Token Usage Report (last ${data.period})`);
-  lines.push('');
-  lines.push(`**Sessions:** ${data.sessions.length}`);
-  lines.push(`**Total turns:** ${data.totals.turns}`);
-  lines.push(`**Estimated cost:** ${formatCost(data.totals.estimatedCostUSD)}`);
-  lines.push('');
-
-  // Token breakdown
-  lines.push('### Token Breakdown');
-  lines.push(`| Type | Tokens |`);
-  lines.push(`|------|--------|`);
-  lines.push(`| Input | ${formatTokens(data.totals.inputTokens)} |`);
-  lines.push(`| Output | ${formatTokens(data.totals.outputTokens)} |`);
-  lines.push(`| Cache write | ${formatTokens(data.totals.cacheWriteTokens)} |`);
-  lines.push(`| Cache read | ${formatTokens(data.totals.cacheReadTokens)} |`);
-  lines.push('');
-
-  // By activity (skills, agents, hooks)
-  const activities = Object.entries(data.byActivity || {}).sort((a, b) => b[1].costUSD - a[1].costUSD);
-  if (activities.length > 0) {
-    lines.push('### By Activity');
-    lines.push(`| Activity | Turns | Input | Output | Model(s) | Cost |`);
-    lines.push(`|----------|-------|-------|--------|----------|------|`);
-    for (const [activity, a] of activities) {
-      const modelList = Object.entries(a.models)
-        .sort((x, y) => y[1] - x[1])
-        .map(([m, count]) => `${m.replace('claude-', '')} (${count})`)
-        .join(', ');
-      lines.push(`| ${activity} | ${a.turns} | ${formatTokens(a.input)} | ${formatTokens(a.output)} | ${modelList} | ${formatCost(a.costUSD)} |`);
-    }
-    lines.push('');
-  }
-
-  // By model
-  const models = Object.entries(data.byModel).sort((a, b) => b[1].costUSD - a[1].costUSD);
-  if (models.length > 0) {
-    lines.push('### By Model');
-    lines.push(`| Model | Turns | Input | Output | Cost |`);
-    lines.push(`|-------|-------|-------|--------|------|`);
-    for (const [model, m] of models) {
-      const shortModel = model.replace('claude-', '');
-      lines.push(`| ${shortModel} | ${m.turns} | ${formatTokens(m.input)} | ${formatTokens(m.output)} | ${formatCost(m.costUSD)} |`);
-    }
-    lines.push('');
-  }
-
-  // By branch
-  const branches = Object.entries(data.byBranch).sort((a, b) => b[1].costUSD - a[1].costUSD);
-  if (branches.length > 0) {
-    lines.push('### By Branch');
-    lines.push(`| Branch | Sessions | Tokens | Cost |`);
-    lines.push(`|--------|----------|--------|------|`);
-    for (const [branch, b] of branches.slice(0, 10)) {
-      lines.push(`| ${branch} | ${b.sessions} | ${formatTokens(b.tokens)} | ${formatCost(b.costUSD)} |`);
-    }
-    if (branches.length > 10) {
-      lines.push(`| ... ${branches.length - 10} more | | | |`);
-    }
-    lines.push('');
-  }
-
-  // Recent sessions
-  const recent = data.sessions
-    .sort((a, b) => new Date(b.date) - new Date(a.date))
-    .slice(0, 10);
-
-  if (recent.length > 0) {
-    lines.push('### Recent Sessions');
-    lines.push(`| Date | Branch | Summary | Turns | Cost |`);
-    lines.push(`|------|--------|---------|-------|------|`);
-    for (const s of recent) {
-      const date = new Date(s.date).toISOString().split('T')[0];
-      const summary = (s.summary || '').slice(0, 40);
-      lines.push(`| ${date} | ${s.branch} | ${summary} | ${s.turns} | ${formatCost(s.estimatedCostUSD)} |`);
-    }
-  }
-
+  lines.push(`Token Usage — last ${data.period} (${data.sessions.length} sessions)`);
+  lines.push(`Total: ${formatTokens(data.totals.totalTokens)} tokens, ${data.totals.turns} turns`);
   return lines.join('\n');
 }
 
@@ -507,29 +358,24 @@ module.exports = {
   getRecentUsage,
   formatReport,
   formatTokens,
-  formatCost,
   detectActivity,
-  PRICING,
+  discoverSessions,
 };
 
 /**
  * @typedef {Object} SessionUsage
- * @property {number} inputTokens
- * @property {number} outputTokens
- * @property {number} cacheWriteTokens
- * @property {number} cacheReadTokens
+ * @property {number} totalTokens
  * @property {number} turns
- * @property {Object<string, {input: number, output: number, cacheWrite: number, cacheRead: number, turns: number, costUSD: number}>} models
- * @property {Object<string, {turns: number, input: number, output: number, cacheWrite: number, cacheRead: number, costUSD: number, models: Object<string, number>}>} activities
- * @property {number} estimatedCostUSD
+ * @property {Object<string, {totalTokens: number, turns: number}>} models
+ * @property {Object<string, {turns: number, totalTokens: number, models: Object<string, number>}>} activities
  */
 
 /**
  * @typedef {Object} AggregatedUsage
  * @property {string} period
  * @property {Array} sessions
- * @property {{inputTokens: number, outputTokens: number, cacheWriteTokens: number, cacheReadTokens: number, turns: number, estimatedCostUSD: number}} totals
- * @property {Object<string, {sessions: number, tokens: number, costUSD: number}>} byBranch
- * @property {Object<string, {turns: number, input: number, output: number, costUSD: number}>} byModel
- * @property {Object<string, {turns: number, input: number, output: number, costUSD: number, models: Object<string, number>}>} byActivity
+ * @property {{totalTokens: number, turns: number}} totals
+ * @property {Object<string, {sessions: number, totalTokens: number}>} byBranch
+ * @property {Object<string, {turns: number, totalTokens: number}>} byModel
+ * @property {Object<string, {turns: number, totalTokens: number, models: Object<string, number>}>} byActivity
  */

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -452,6 +452,15 @@ function formatReport(data) {
   lines.push(`Token Usage — last ${data.period} (${data.sessions.length} sessions)`);
   lines.push('');
 
+  // BY PROJECT (only when cross-project data exists)
+  const projects = Object.entries(data.byProject || {})
+    .map(([name, p]) => [name, p.totalTokens])
+    .sort((a, b) => b[1] - a[1]);
+  if (projects.length > 0) {
+    lines.push(renderSection('PROJECT', projects, total));
+    lines.push('');
+  }
+
   // BY ACTIVITY
   const activities = Object.entries(data.byActivity || {})
     .map(([label, a]) => [label, a.totalTokens])
@@ -482,6 +491,42 @@ function formatReport(data) {
   return lines.join('\n');
 }
 
+/**
+ * Decode a Claude projects directory name into a human-readable project name.
+ * Takes the last two meaningful path segments.
+ * e.g., "-Users-rutger-Projects-EnvoyProject-envoy" → "EnvoyProject/envoy"
+ *
+ * @param {string} encodedDir
+ * @returns {string}
+ */
+function decodeProjectName(encodedDir) {
+  // Split on '-', filter empty strings (leading dash produces empty first element)
+  const segments = encodedDir.split('-').filter(Boolean);
+  if (segments.length < 2) return segments.join('/');
+  return segments.slice(-2).join('/');
+}
+
+/**
+ * Discover all Claude project directories.
+ * @returns {Array<{name: string, projectDir: string}>}
+ */
+function discoverAllProjects() {
+  const projectsRoot = path.resolve(os.homedir(), '.claude', 'projects');
+  try {
+    return fs.readdirSync(projectsRoot)
+      .filter(d => {
+        const fullPath = path.join(projectsRoot, d);
+        return fs.statSync(fullPath).isDirectory();
+      })
+      .map(d => ({
+        name: decodeProjectName(d),
+        projectDir: path.join(projectsRoot, d),
+      }));
+  } catch {
+    return [];
+  }
+}
+
 module.exports = {
   findProjectDir,
   loadSessionsIndex,
@@ -494,6 +539,8 @@ module.exports = {
   detectActivity,
   classifyPhase,
   discoverSessions,
+  decodeProjectName,
+  discoverAllProjects,
 };
 
 /**

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -461,6 +461,15 @@ function formatReport(data) {
     lines.push('');
   }
 
+  // BY CONTRIBUTOR (only when team data exists)
+  const contributors = Object.entries(data.byContributor || {})
+    .map(([name, c]) => [name, c.totalTokens])
+    .sort((a, b) => b[1] - a[1]);
+  if (contributors.length > 0) {
+    lines.push(renderSection('CONTRIBUTOR', contributors, total));
+    lines.push('');
+  }
+
   // BY ACTIVITY
   const activities = Object.entries(data.byActivity || {})
     .map(([label, a]) => [label, a.totalTokens])
@@ -489,6 +498,80 @@ function formatReport(data) {
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Aggregate team cost reports from committed JSON files.
+ * @param {string} reportsDir - Path to docs/costs/reports/
+ * @param {Object} [options]
+ * @param {number} [options.days] - Filter to last N days
+ * @param {string} [options.branch] - Filter by branch
+ * @returns {{totals: {totalTokens: number, turns: number}, byContributor: Object, byActivity: Object, byModel: Object}}
+ */
+function aggregateTeamReports(reportsDir, options = {}) {
+  const result = {
+    totals: { totalTokens: 0, turns: 0 },
+    byContributor: {},
+    byActivity: {},
+    byModel: {},
+  };
+
+  let files;
+  try {
+    files = fs.readdirSync(reportsDir).filter(f => f.endsWith('.json'));
+  } catch {
+    return result;
+  }
+
+  const cutoff = options.days
+    ? new Date(Date.now() - options.days * 24 * 60 * 60 * 1000)
+    : null;
+
+  for (const file of files) {
+    let report;
+    try {
+      report = JSON.parse(fs.readFileSync(path.join(reportsDir, file), 'utf8'));
+    } catch {
+      continue;
+    }
+
+    // Filter by date
+    if (cutoff && new Date(report.date) < cutoff) continue;
+    // Filter by branch
+    if (options.branch && report.branch !== options.branch) continue;
+
+    const tokens = report.totalTokens || 0;
+    const turns = report.turns || 0;
+
+    result.totals.totalTokens += tokens;
+    result.totals.turns += turns;
+
+    // By contributor
+    const user = report.user || 'unknown';
+    if (!result.byContributor[user]) {
+      result.byContributor[user] = { totalTokens: 0, turns: 0 };
+    }
+    result.byContributor[user].totalTokens += tokens;
+    result.byContributor[user].turns += turns;
+
+    // By activity
+    for (const [activity, actTokens] of Object.entries(report.activities || {})) {
+      if (!result.byActivity[activity]) {
+        result.byActivity[activity] = { totalTokens: 0 };
+      }
+      result.byActivity[activity].totalTokens += actTokens;
+    }
+
+    // By model
+    for (const [model, modelTokens] of Object.entries(report.models || {})) {
+      if (!result.byModel[model]) {
+        result.byModel[model] = { totalTokens: 0 };
+      }
+      result.byModel[model].totalTokens += modelTokens;
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -541,6 +624,7 @@ module.exports = {
   discoverSessions,
   decodeProjectName,
   discoverAllProjects,
+  aggregateTeamReports,
 };
 
 /**

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -431,7 +431,7 @@ function renderSection(title, entries, grandTotal) {
 
   for (const [label, tokens] of entries) {
     const pct = grandTotal > 0 ? (tokens / grandTotal) * 100 : 0;
-    const bar = renderBar(tokens / grandTotal);
+    const bar = renderBar(grandTotal > 0 ? tokens / grandTotal : 0);
     const padLabel = label.padEnd(maxLabel);
     const padPct = pct.toFixed(1).padStart(5) + '%';
     const padTokens = (formatTokens(tokens) + ' tokens').padStart(12);

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -402,14 +402,83 @@ function formatTokens(n) {
 }
 
 /**
- * Format aggregated usage as a readable report (placeholder — replaced in Task 3).
+ * Render a bar chart of the given fraction.
+ * @param {number} fraction - 0..1
+ * @param {number} [width=20]
+ * @returns {string}
+ */
+function renderBar(fraction, width = 20) {
+  const filled = Math.round(fraction * width);
+  return '\u2588'.repeat(filled) + '\u2591'.repeat(width - filled);
+}
+
+/**
+ * Render a section of the report (BY ACTIVITY, BY MODEL, etc.).
+ * Entries: array of [label, totalTokens]. Sorted descending by tokens.
+ *
+ * @param {string} title
+ * @param {Array<[string, number]>} entries - [label, totalTokens]
+ * @param {number} grandTotal
+ * @returns {string}
+ */
+function renderSection(title, entries, grandTotal) {
+  if (entries.length === 0) return '';
+  const lines = [];
+  lines.push(` BY ${title}`);
+
+  // Find longest label for alignment
+  const maxLabel = Math.max(...entries.map(([l]) => l.length));
+
+  for (const [label, tokens] of entries) {
+    const pct = grandTotal > 0 ? (tokens / grandTotal) * 100 : 0;
+    const bar = renderBar(tokens / grandTotal);
+    const padLabel = label.padEnd(maxLabel);
+    const padPct = pct.toFixed(1).padStart(5) + '%';
+    const padTokens = (formatTokens(tokens) + ' tokens').padStart(12);
+    lines.push(` ${padLabel}  ${bar}  ${padPct}  ${padTokens}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format aggregated usage as a compact bar-chart report.
  * @param {AggregatedUsage} data
  * @returns {string}
  */
 function formatReport(data) {
   const lines = [];
+  const total = data.totals.totalTokens;
+
   lines.push(`Token Usage — last ${data.period} (${data.sessions.length} sessions)`);
-  lines.push(`Total: ${formatTokens(data.totals.totalTokens)} tokens, ${data.totals.turns} turns`);
+  lines.push('');
+
+  // BY ACTIVITY
+  const activities = Object.entries(data.byActivity || {})
+    .map(([label, a]) => [label, a.totalTokens])
+    .sort((a, b) => b[1] - a[1]);
+  if (activities.length > 0) {
+    lines.push(renderSection('ACTIVITY', activities, total));
+    lines.push('');
+  }
+
+  // BY MODEL
+  const models = Object.entries(data.byModel || {})
+    .map(([model, m]) => [model.replace('claude-', ''), m.totalTokens])
+    .sort((a, b) => b[1] - a[1]);
+  if (models.length > 0) {
+    lines.push(renderSection('MODEL', models, total));
+    lines.push('');
+  }
+
+  // BY BRANCH
+  const branches = Object.entries(data.byBranch || {})
+    .map(([branch, b]) => [branch, b.totalTokens])
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  if (branches.length > 0) {
+    lines.push(renderSection('BRANCH', branches, total));
+  }
+
   return lines.join('\n');
 }
 
@@ -421,6 +490,7 @@ module.exports = {
   getRecentUsage,
   formatReport,
   formatTokens,
+  renderBar,
   detectActivity,
   classifyPhase,
   discoverSessions,

--- a/lib/cost-reporter.js
+++ b/lib/cost-reporter.js
@@ -90,12 +90,54 @@ function detectActivity(msg) {
     }
   }
 
-  return 'general';
+  return null; // No explicit label — needs phase inference
 }
 
 /**
+ * Extract tool names from an assistant message's content blocks.
+ * @param {object} msg
+ * @returns {string[]}
+ */
+function extractToolNames(msg) {
+  const blocks = Array.isArray(msg.content) ? msg.content : [];
+  return blocks
+    .filter(b => b.type === 'tool_use')
+    .map(b => b.name);
+}
+
+/**
+ * Classify the phase of work from a window of tool names.
+ * Evaluated top-to-bottom, first match wins.
+ *
+ * @param {string[]} tools - Flat array of tool names from the window
+ * @returns {string} Phase label
+ */
+function classifyPhase(tools) {
+  const counts = {};
+  for (const t of tools) {
+    counts[t] = (counts[t] || 0) + 1;
+  }
+  const editWrite = (counts['Edit'] || 0) + (counts['Write'] || 0);
+  const bash = counts['Bash'] || 0;
+  const grep = counts['Grep'] || 0;
+  const read = counts['Read'] || 0;
+  const agent = counts['Agent'] || 0;
+  const ask = counts['AskUserQuestion'] || 0;
+  const taskCreate = counts['TaskCreate'] || 0;
+
+  if (editWrite > 5 && bash > 3) return 'implementation';
+  if (bash > 5 && grep > 2 && editWrite < 3) return 'debugging';
+  if (read > 5 && editWrite < 2 && agent > 0) return 'review';
+  if (ask > 3) return 'interactive';
+  if (taskCreate > 1 || (agent > 1 && editWrite < 3)) return 'planning';
+  return 'other';
+}
+
+const WINDOW_RADIUS = 5;
+
+/**
  * Extract token usage from a session JSONL file.
- * Tracks usage per model AND per Envoy activity (skill, agent, hook).
+ * Two-pass: first collects turns, then classifies with windowed phase inference.
  *
  * @param {string} jsonlPath
  * @returns {SessionUsage}
@@ -112,6 +154,8 @@ function extractSessionUsage(jsonlPath) {
     const content = fs.readFileSync(jsonlPath, 'utf8');
     const lines = content.split('\n').filter(l => l.trim());
 
+    // Pass 1: collect all assistant turns with metadata
+    const turns = [];
     for (const line of lines) {
       let obj;
       try {
@@ -119,25 +163,44 @@ function extractSessionUsage(jsonlPath) {
       } catch {
         continue;
       }
-
       if (obj.type !== 'assistant') continue;
-
       const msg = obj.message;
       if (!msg || !msg.usage) continue;
 
-      const u = msg.usage;
-      const model = msg.model || 'unknown';
-      const activity = detectActivity(msg);
-      const turnTokens = sumTokens(u);
+      turns.push({
+        usage: msg.usage,
+        model: msg.model || 'unknown',
+        explicitActivity: detectActivity(msg),
+        tools: extractToolNames(msg),
+      });
+    }
+
+    // Pass 2: classify each turn, using window for phase inference
+    for (let i = 0; i < turns.length; i++) {
+      const turn = turns[i];
+      const turnTokens = sumTokens(turn.usage);
+
+      // Determine activity: explicit label or window-based inference
+      let activity = turn.explicitActivity;
+      if (!activity) {
+        // Build tool window: 5 turns before, current, 5 after
+        const windowTools = [];
+        const start = Math.max(0, i - WINDOW_RADIUS);
+        const end = Math.min(turns.length - 1, i + WINDOW_RADIUS);
+        for (let j = start; j <= end; j++) {
+          windowTools.push(...turns[j].tools);
+        }
+        activity = classifyPhase(windowTools);
+      }
 
       usage.totalTokens += turnTokens;
       usage.turns += 1;
 
       // Track per-model
-      if (!usage.models[model]) {
-        usage.models[model] = { totalTokens: 0, turns: 0 };
+      if (!usage.models[turn.model]) {
+        usage.models[turn.model] = { totalTokens: 0, turns: 0 };
       }
-      const m = usage.models[model];
+      const m = usage.models[turn.model];
       m.totalTokens += turnTokens;
       m.turns += 1;
 
@@ -150,8 +213,8 @@ function extractSessionUsage(jsonlPath) {
       a.totalTokens += turnTokens;
 
       // Track model within activity
-      if (!a.models[model]) a.models[model] = 0;
-      a.models[model] += 1;
+      if (!a.models[turn.model]) a.models[turn.model] = 0;
+      a.models[turn.model] += 1;
     }
   } catch {
     // File unreadable
@@ -359,6 +422,7 @@ module.exports = {
   formatReport,
   formatTokens,
   detectActivity,
+  classifyPhase,
   discoverSessions,
 };
 

--- a/skills/costs/SKILL.md
+++ b/skills/costs/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: costs
-description: Use when you want to see token usage and estimated costs for this project
+description: Use when you want to see token usage breakdown by activity, model, and branch
 ---
 
-# Token Usage & Cost Report
+# Token Usage Report
 
 ## Overview
 
-Show token usage and estimated costs from Claude Code session logs for this project. Reads Claude Code's native JSONL session files — no separate tracking needed.
+Show where tokens go — which skills, phases, models, and branches consume the most. Reads Claude Code's native JSONL session files with phase inference for unlabeled turns. No dollar estimates — just token counts and percentages.
 
 **Announce at start:** "I'm using envoy:costs to generate a token usage report."
 
@@ -16,7 +16,7 @@ Show token usage and estimated costs from Claude Code session logs for this proj
 ### Step 1: Load Cost Reporter
 
 ```javascript
-const { findProjectDir, getRecentUsage, formatReport } = require('../../lib/cost-reporter');
+const { findProjectDir, getRecentUsage, formatReport, aggregateTeamReports, discoverAllProjects } = require('../../lib/cost-reporter');
 const projectDir = findProjectDir(process.cwd());
 ```
 
@@ -37,11 +37,17 @@ console.log(formatReport(data));
 | `--days N` | Look back N days (default: 7) |
 | `--branch <name>` | Filter to a specific branch |
 | `--session` | Show current session only |
+| `--all` | Aggregate across all projects |
+| `--team` | Aggregate team reports from `docs/costs/reports/` |
 
 ```javascript
-// Examples
-const data = getRecentUsage(projectDir, { days: 30 });
-const data = getRecentUsage(projectDir, { branch: 'feature/auth' });
+// Cross-project
+const projects = discoverAllProjects();
+// aggregate across all project dirs...
+
+// Team view
+const teamData = aggregateTeamReports('docs/costs/reports/', { days: 30 });
+console.log(formatReport(teamData));
 ```
 
 For `--session`, use the current session ID:
@@ -52,24 +58,28 @@ const usage = getSessionUsage(projectDir, process.env.CLAUDE_SESSION_ID);
 
 ### Step 3: Display Report
 
-The formatted report includes:
-- **Token breakdown** — input, output, cache write, cache read
-- **By model** — which models consumed what (opus vs sonnet vs haiku)
-- **By branch** — cost per feature branch
-- **Recent sessions** — last 10 sessions with date, summary, cost
+Output is compact plain-text with bar charts. Sections include:
+- **BY PROJECT** — only with `--all` flag
+- **BY CONTRIBUTOR** — only with `--team` flag
+- **BY ACTIVITY** — skills, agents, and inferred phases (implementation, debugging, review, etc.)
+- **BY MODEL** — token distribution across opus/sonnet/haiku
+- **BY BRANCH** — token usage per feature branch
+
+All sorted by token count descending.
 
 ### Step 4: Insights (optional)
 
 If the user asks for optimization suggestions, analyze the data:
 
-- **High cache write / low cache read ratio** — sessions not benefiting from caching, consider longer sessions
-- **Most cost on opus** — check if some tasks could use sonnet (mechanical/simple tasks)
-- **Expensive branches** — flag branches with disproportionate cost vs. code changes
+- **Most tokens on a single skill** — check if that skill can be streamlined
+- **High opus usage** — check if some tasks could use sonnet (mechanical/simple tasks)
+- **Expensive branches** — flag branches with disproportionate token usage vs. code changes
 - **Many short sessions** — session restarts incur cache write costs; longer sessions are cheaper
 
 ## Integration with Envoy
 
 **Libraries used:**
-- `lib/cost-reporter.js` — Reads Claude Code session JSONL, aggregates usage, estimates costs
+- `lib/cost-reporter.js` — Reads Claude Code session JSONL, aggregates usage with phase inference
 
 **Data source:** `~/.claude/projects/<project-id>/<session>.jsonl` (Claude Code native format)
+**Team data:** `docs/costs/reports/*.json` (committed by session-end hook)

--- a/skills/costs/SKILL.md
+++ b/skills/costs/SKILL.md
@@ -42,8 +42,8 @@ console.log(formatReport(data));
 
 ```javascript
 // Cross-project
-const projects = discoverAllProjects();
-// aggregate across all project dirs...
+const data = getAllProjectsUsage({ days: 30 });
+console.log(formatReport(data));
 
 // Team view
 const teamData = aggregateTeamReports('docs/costs/reports/', { days: 30 });

--- a/tests/envoy-2.1.test.js
+++ b/tests/envoy-2.1.test.js
@@ -789,14 +789,14 @@ test('Agent tool_use detected', () => {
   assert.strictEqual(costReporter.detectActivity(msg), 'agent:Explore');
 });
 
-test('Text-only message returns general', () => {
+test('Text-only message returns null (needs phase inference)', () => {
   const msg = { content: [{ type: 'text', text: 'Just a normal response' }] };
-  assert.strictEqual(costReporter.detectActivity(msg), 'general');
+  assert.strictEqual(costReporter.detectActivity(msg), null);
 });
 
 test('Edit tool with envoy: in new_string is NOT a false positive', () => {
   const msg = { content: [{ type: 'tool_use', name: 'Edit', input: { new_string: 'envoy:brainstorm example' } }] };
-  assert.strictEqual(costReporter.detectActivity(msg), 'general');
+  assert.strictEqual(costReporter.detectActivity(msg), null);
 });
 
 test('Review-related text detected', () => {
@@ -804,9 +804,9 @@ test('Review-related text detected', () => {
   assert.strictEqual(costReporter.detectActivity(msg), 'review');
 });
 
-test('Non-array content returns general', () => {
+test('Non-array content returns null', () => {
   const msg = { content: 'just a string' };
-  assert.strictEqual(costReporter.detectActivity(msg), 'general');
+  assert.strictEqual(costReporter.detectActivity(msg), null);
 });
 
 section('cost-reporter: formatTokens');
@@ -823,29 +823,10 @@ test('Small numbers as-is', () => {
   assert.strictEqual(costReporter.formatTokens(500), '500');
 });
 
-section('cost-reporter: formatCost');
+section('cost-reporter: classifyPhase');
 
-test('Dollar amounts formatted correctly', () => {
-  assert.strictEqual(costReporter.formatCost(1.5), '$1.50');
-  assert.strictEqual(costReporter.formatCost(0.05), '$0.05');
-  assert.strictEqual(costReporter.formatCost(0.001), '$0.0010');
-});
-
-section('cost-reporter: pricing');
-
-test('All model tiers have pricing', () => {
-  assert(costReporter.PRICING['claude-opus-4-6']);
-  assert(costReporter.PRICING['claude-sonnet-4-6']);
-  assert(costReporter.PRICING['claude-haiku-4-5']);
-});
-
-test('Each pricing has all rate types', () => {
-  for (const [, p] of Object.entries(costReporter.PRICING)) {
-    assert(typeof p.input === 'number');
-    assert(typeof p.output === 'number');
-    assert(typeof p.cacheWrite === 'number');
-    assert(typeof p.cacheRead === 'number');
-  }
+test('classifyPhase is exported', () => {
+  assert.strictEqual(typeof costReporter.classifyPhase, 'function');
 });
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/hooks/cost-summary-export.test.js
+++ b/tests/hooks/cost-summary-export.test.js
@@ -60,13 +60,14 @@ test('buildSummaryJson produces valid JSON structure', () => {
     },
   };
 
-  const summary = hook.buildSummaryJson(mockUsage, 'rutger', 'feature/16-costs');
+  const now = new Date('2026-04-06T14:30:00.000Z');
+  const summary = hook.buildSummaryJson(mockUsage, 'rutger', 'feature/16-costs', now);
 
   assert.strictEqual(summary.user, 'rutger');
   assert.strictEqual(summary.branch, 'feature/16-costs');
   assert.strictEqual(summary.totalTokens, 5000);
   assert.strictEqual(summary.turns, 10);
-  assert.ok(summary.date, 'Should have date');
+  assert.strictEqual(summary.date, '2026-04-06');
   assert.deepStrictEqual(summary.activities, { 'skill:review': 3000, 'implementation': 2000 });
   assert.deepStrictEqual(summary.models, { 'claude-opus-4-6': 4000, 'claude-sonnet-4-6': 1000 });
 });
@@ -78,16 +79,27 @@ test('buildSummaryJson has no costUSD field', () => {
     activities: {},
     models: {},
   };
-  const summary = hook.buildSummaryJson(mockUsage, 'user', 'main');
+  const now = new Date('2026-04-06T14:30:00.000Z');
+  const summary = hook.buildSummaryJson(mockUsage, 'user', 'main', now);
   assert.strictEqual(summary.costUSD, undefined);
 });
 
-test('getExportPath returns expected format', () => {
+test('getExportPath includes timestamp for uniqueness', () => {
   assert.strictEqual(typeof hook.getExportPath, 'function');
-  const exportPath = hook.getExportPath('/tmp/project', 'rutger');
+  const now = new Date('2026-04-06T14:30:45.123Z');
+  const exportPath = hook.getExportPath('/tmp/project', 'rutger', now);
   assert.ok(exportPath.includes('docs/costs/reports/'), 'Should be in docs/costs/reports/');
   assert.ok(exportPath.includes('rutger'), 'Should contain username');
+  assert.ok(exportPath.includes('143045'), 'Should contain timestamp');
   assert.ok(exportPath.endsWith('.json'), 'Should end with .json');
+});
+
+test('getExportPath produces unique names for same user same day', () => {
+  const t1 = new Date('2026-04-06T10:00:00.000Z');
+  const t2 = new Date('2026-04-06T15:30:00.000Z');
+  const p1 = hook.getExportPath('/tmp/project', 'rutger', t1);
+  const p2 = hook.getExportPath('/tmp/project', 'rutger', t2);
+  assert.notStrictEqual(p1, p2, 'Paths should differ for different times on same day');
 });
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/hooks/cost-summary-export.test.js
+++ b/tests/hooks/cost-summary-export.test.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Cost Summary Export Hook — Test Suite
+ *
+ * Run: node tests/hooks/cost-summary-export.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const HOOKS = path.join(__dirname, '..', '..', 'hooks');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Load module
+// ═══════════════════════════════════════════════════════════════════
+
+const hook = require(path.join(HOOKS, 'cost-summary-export'));
+
+// ═══════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════
+
+section('cost-summary-export: buildSummaryJson');
+
+test('buildSummaryJson is exported', () => {
+  assert.strictEqual(typeof hook.buildSummaryJson, 'function');
+});
+
+test('buildSummaryJson produces valid JSON structure', () => {
+  const mockUsage = {
+    totalTokens: 5000,
+    turns: 10,
+    activities: {
+      'skill:review': { totalTokens: 3000, turns: 5, models: {} },
+      'implementation': { totalTokens: 2000, turns: 5, models: {} },
+    },
+    models: {
+      'claude-opus-4-6': { totalTokens: 4000, turns: 8 },
+      'claude-sonnet-4-6': { totalTokens: 1000, turns: 2 },
+    },
+  };
+
+  const summary = hook.buildSummaryJson(mockUsage, 'rutger', 'feature/16-costs');
+
+  assert.strictEqual(summary.user, 'rutger');
+  assert.strictEqual(summary.branch, 'feature/16-costs');
+  assert.strictEqual(summary.totalTokens, 5000);
+  assert.strictEqual(summary.turns, 10);
+  assert.ok(summary.date, 'Should have date');
+  assert.deepStrictEqual(summary.activities, { 'skill:review': 3000, 'implementation': 2000 });
+  assert.deepStrictEqual(summary.models, { 'claude-opus-4-6': 4000, 'claude-sonnet-4-6': 1000 });
+});
+
+test('buildSummaryJson has no costUSD field', () => {
+  const mockUsage = {
+    totalTokens: 100,
+    turns: 1,
+    activities: {},
+    models: {},
+  };
+  const summary = hook.buildSummaryJson(mockUsage, 'user', 'main');
+  assert.strictEqual(summary.costUSD, undefined);
+});
+
+test('getExportPath returns expected format', () => {
+  assert.strictEqual(typeof hook.getExportPath, 'function');
+  const exportPath = hook.getExportPath('/tmp/project', 'rutger');
+  assert.ok(exportPath.includes('docs/costs/reports/'), 'Should be in docs/costs/reports/');
+  assert.ok(exportPath.includes('rutger'), 'Should contain username');
+  assert.ok(exportPath.endsWith('.json'), 'Should end with .json');
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Summary
+// ═══════════════════════════════════════════════════════════════════
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/cost-reporter.test.js
+++ b/tests/lib/cost-reporter.test.js
@@ -236,6 +236,20 @@ test('renderBar produces all empty for 0%', () => {
   assert.strictEqual(empty, 20);
 });
 
+test('formatReport does not crash when totals are zero', () => {
+  const emptyData = {
+    period: '7 days',
+    sessions: [],
+    totals: { totalTokens: 0, turns: 0 },
+    byActivity: { 'other': { turns: 0, totalTokens: 0, models: {} } },
+    byModel: {},
+    byBranch: {},
+  };
+  // Should not throw
+  const report = costReporter.formatReport(emptyData);
+  assert.ok(typeof report === 'string');
+});
+
 const mockAggregated = {
   period: '7 days',
   sessions: [{ id: 's1' }, { id: 's2' }],

--- a/tests/lib/cost-reporter.test.js
+++ b/tests/lib/cost-reporter.test.js
@@ -292,6 +292,52 @@ test('formatReport sorts activities by totalTokens descending', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════
+// Task 4: Cross-project discovery
+// ═══════════════════════════════════════════════════════════════════
+
+section('cross-project: decodeProjectName');
+
+test('decodeProjectName is exported', () => {
+  assert.strictEqual(typeof costReporter.decodeProjectName, 'function');
+});
+
+test('decodeProjectName extracts last two segments', () => {
+  const result = costReporter.decodeProjectName('-Users-rutger-Projects-EnvoyProject-envoy');
+  assert.strictEqual(result, 'EnvoyProject/envoy');
+});
+
+test('decodeProjectName handles single segment', () => {
+  const result = costReporter.decodeProjectName('-Users-rutger-myproject');
+  assert.strictEqual(result, 'rutger/myproject');
+});
+
+test('decodeProjectName handles deep paths', () => {
+  const result = costReporter.decodeProjectName('-Users-rutger-Projects-Work-Client-api');
+  assert.strictEqual(result, 'Client/api');
+});
+
+test('discoverAllProjects is exported', () => {
+  assert.strictEqual(typeof costReporter.discoverAllProjects, 'function');
+});
+
+test('discoverAllProjects returns an array', () => {
+  const projects = costReporter.discoverAllProjects();
+  assert.ok(Array.isArray(projects), 'Should return an array');
+});
+
+test('formatReport includes BY PROJECT when byProject data exists', () => {
+  const data = {
+    ...mockAggregated,
+    byProject: {
+      'EnvoyProject/envoy': { totalTokens: 8000 },
+      'Other/project': { totalTokens: 2000 },
+    },
+  };
+  const report = costReporter.formatReport(data);
+  assert.ok(report.includes('BY PROJECT'), 'Should contain BY PROJECT section');
+});
+
+// ═══════════════════════════════════════════════════════════════════
 // Summary
 // ═══════════════════════════════════════════════════════════════════
 

--- a/tests/lib/cost-reporter.test.js
+++ b/tests/lib/cost-reporter.test.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Cost Reporter — Test Suite
+ *
+ * Run: node tests/lib/cost-reporter.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const LIB = path.join(__dirname, '..', '..', 'lib');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+/**
+ * Helper: write a temporary JSONL file with assistant messages.
+ */
+function writeTempJsonl(lines) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cost-reporter-test-'));
+  const jsonlPath = path.join(tmpDir, 'test-session.jsonl');
+  const content = lines.map(l => JSON.stringify(l)).join('\n');
+  fs.writeFileSync(jsonlPath, content);
+  return { tmpDir, jsonlPath };
+}
+
+function cleanup(tmpDir) {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Load module
+// ═══════════════════════════════════════════════════════════════════
+
+const costReporter = require(path.join(LIB, 'cost-reporter'));
+
+// ═══════════════════════════════════════════════════════════════════
+// Task 1: Token aggregation — no dollar estimates
+// ═══════════════════════════════════════════════════════════════════
+
+section('extractSessionUsage: token-based aggregation');
+
+test('extractSessionUsage returns totalTokens field', () => {
+  const { tmpDir, jsonlPath } = writeTempJsonl([
+    {
+      type: 'assistant',
+      message: {
+        model: 'claude-opus-4-6-20260301',
+        usage: { input_tokens: 1000, output_tokens: 200, cache_creation_input_tokens: 50, cache_read_input_tokens: 300 },
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    },
+  ]);
+  const usage = costReporter.extractSessionUsage(jsonlPath);
+  assert.strictEqual(usage.totalTokens, 1550, `Expected totalTokens=1550, got ${usage.totalTokens}`);
+  cleanup(tmpDir);
+});
+
+test('extractSessionUsage does NOT have estimatedCostUSD', () => {
+  const { tmpDir, jsonlPath } = writeTempJsonl([
+    {
+      type: 'assistant',
+      message: {
+        model: 'claude-opus-4-6-20260301',
+        usage: { input_tokens: 100, output_tokens: 50 },
+        content: [{ type: 'text', text: 'hi' }],
+      },
+    },
+  ]);
+  const usage = costReporter.extractSessionUsage(jsonlPath);
+  assert.strictEqual(usage.estimatedCostUSD, undefined, 'Should not have estimatedCostUSD');
+  cleanup(tmpDir);
+});
+
+test('extractSessionUsage does NOT have costUSD on models', () => {
+  const { tmpDir, jsonlPath } = writeTempJsonl([
+    {
+      type: 'assistant',
+      message: {
+        model: 'claude-sonnet-4-6-20260301',
+        usage: { input_tokens: 500, output_tokens: 100 },
+        content: [{ type: 'text', text: 'test' }],
+      },
+    },
+  ]);
+  const usage = costReporter.extractSessionUsage(jsonlPath);
+  const modelData = usage.models['claude-sonnet-4-6-20260301'];
+  assert.ok(modelData, 'Model should be tracked');
+  assert.strictEqual(modelData.costUSD, undefined, 'Model should not have costUSD');
+  assert.ok(typeof modelData.totalTokens === 'number', 'Model should have totalTokens');
+  cleanup(tmpDir);
+});
+
+test('extractSessionUsage aggregates totalTokens across turns', () => {
+  const { tmpDir, jsonlPath } = writeTempJsonl([
+    {
+      type: 'assistant',
+      message: {
+        model: 'claude-opus-4-6',
+        usage: { input_tokens: 1000, output_tokens: 200 },
+        content: [{ type: 'text', text: 'turn 1' }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        model: 'claude-opus-4-6',
+        usage: { input_tokens: 500, output_tokens: 100 },
+        content: [{ type: 'text', text: 'turn 2' }],
+      },
+    },
+  ]);
+  const usage = costReporter.extractSessionUsage(jsonlPath);
+  assert.strictEqual(usage.totalTokens, 1800, `Expected 1800, got ${usage.totalTokens}`);
+  assert.strictEqual(usage.turns, 2);
+  cleanup(tmpDir);
+});
+
+test('PRICING constant is not exported', () => {
+  assert.strictEqual(costReporter.PRICING, undefined, 'PRICING should not be exported');
+});
+
+test('formatCost is not exported', () => {
+  assert.strictEqual(costReporter.formatCost, undefined, 'formatCost should not be exported');
+});
+
+test('formatTokens is still exported', () => {
+  assert.strictEqual(typeof costReporter.formatTokens, 'function', 'formatTokens should still be exported');
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Summary
+// ═══════════════════════════════════════════════════════════════════
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/cost-reporter.test.js
+++ b/tests/lib/cost-reporter.test.js
@@ -339,6 +339,17 @@ test('discoverAllProjects returns an array', () => {
   assert.ok(Array.isArray(projects), 'Should return an array');
 });
 
+test('getAllProjectsUsage is exported', () => {
+  assert.strictEqual(typeof costReporter.getAllProjectsUsage, 'function');
+});
+
+test('getAllProjectsUsage returns data with byProject', () => {
+  const result = costReporter.getAllProjectsUsage({ days: 7 });
+  assert.ok(result.byProject, 'Should have byProject');
+  assert.ok(result.period, 'Should have period');
+  assert.ok(Array.isArray(result.sessions), 'Should have sessions array');
+});
+
 test('formatReport includes BY PROJECT when byProject data exists', () => {
   const data = {
     ...mockAggregated,

--- a/tests/lib/cost-reporter.test.js
+++ b/tests/lib/cost-reporter.test.js
@@ -146,6 +146,68 @@ test('formatTokens is still exported', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════
+// Task 2: Phase inference — classifyPhase
+// ═══════════════════════════════════════════════════════════════════
+
+section('classifyPhase: tool-window inference');
+
+test('classifyPhase is exported', () => {
+  assert.strictEqual(typeof costReporter.classifyPhase, 'function', 'classifyPhase should be exported');
+});
+
+test('classifyPhase detects implementation (Edit/Write heavy + Bash)', () => {
+  const tools = ['Edit', 'Edit', 'Bash', 'Write', 'Edit', 'Bash', 'Edit', 'Bash', 'Edit', 'Write', 'Bash'];
+  assert.strictEqual(costReporter.classifyPhase(tools), 'implementation');
+});
+
+test('classifyPhase detects debugging (Bash + Grep heavy, low Edit)', () => {
+  const tools = ['Bash', 'Bash', 'Grep', 'Read', 'Bash', 'Grep', 'Bash', 'Grep', 'Bash', 'Bash'];
+  assert.strictEqual(costReporter.classifyPhase(tools), 'debugging');
+});
+
+test('classifyPhase detects review (Read heavy + Agent, low Edit)', () => {
+  const tools = ['Read', 'Read', 'Read', 'Read', 'Read', 'Read', 'Agent'];
+  assert.strictEqual(costReporter.classifyPhase(tools), 'review');
+});
+
+test('classifyPhase detects interactive (AskUserQuestion heavy)', () => {
+  const tools = ['AskUserQuestion', 'Read', 'AskUserQuestion', 'AskUserQuestion', 'AskUserQuestion'];
+  assert.strictEqual(costReporter.classifyPhase(tools), 'interactive');
+});
+
+test('classifyPhase detects planning (TaskCreate + Agent, low Edit)', () => {
+  const tools = ['Read', 'Agent', 'Agent', 'TaskCreate', 'TaskCreate', 'Read'];
+  assert.strictEqual(costReporter.classifyPhase(tools), 'planning');
+});
+
+test('classifyPhase returns other for ambiguous tools', () => {
+  const tools = ['Read', 'Read'];
+  assert.strictEqual(costReporter.classifyPhase(tools), 'other');
+});
+
+test('extractSessionUsage uses phase inference for unlabeled turns', () => {
+  // Build a session with Edit-heavy turns (no Skill/Agent tool calls)
+  const turns = [];
+  for (let i = 0; i < 11; i++) {
+    const toolName = i % 3 === 0 ? 'Bash' : (i % 3 === 1 ? 'Edit' : 'Write');
+    turns.push({
+      type: 'assistant',
+      message: {
+        model: 'claude-opus-4-6',
+        usage: { input_tokens: 100, output_tokens: 50 },
+        content: [{ type: 'tool_use', name: toolName, input: {} }],
+      },
+    });
+  }
+  const { tmpDir, jsonlPath } = writeTempJsonl(turns);
+  const usage = costReporter.extractSessionUsage(jsonlPath);
+  // Most turns should be labeled 'implementation', not 'general'
+  assert.ok(usage.activities['implementation'], 'Should have implementation activity');
+  assert.strictEqual(usage.activities['general'], undefined, 'Should not have general activity');
+  cleanup(tmpDir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
 // Summary
 // ═══════════════════════════════════════════════════════════════════
 

--- a/tests/lib/cost-reporter.test.js
+++ b/tests/lib/cost-reporter.test.js
@@ -408,6 +408,22 @@ test('aggregateTeamReports filters by days', () => {
   cleanup(tmpDir);
 });
 
+test('aggregateTeamReports output is compatible with formatReport', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'team-compat-'));
+  const reportsDir = path.join(tmpDir, 'reports');
+  fs.mkdirSync(reportsDir, { recursive: true });
+  fs.writeFileSync(path.join(reportsDir, '2026-04-06-test.json'), JSON.stringify({
+    date: '2026-04-06', user: 'test', branch: 'main', totalTokens: 100, turns: 1,
+    activities: { 'other': 100 }, models: { 'claude-opus-4-6': 100 },
+  }));
+  const teamData = costReporter.aggregateTeamReports(reportsDir);
+  // Should not throw
+  const report = costReporter.formatReport(teamData);
+  assert.ok(typeof report === 'string');
+  assert.ok(report.includes('BY CONTRIBUTOR'));
+  cleanup(tmpDir);
+});
+
 test('formatReport includes BY CONTRIBUTOR when byContributor exists', () => {
   const data = {
     ...mockAggregated,

--- a/tests/lib/cost-reporter.test.js
+++ b/tests/lib/cost-reporter.test.js
@@ -208,6 +208,90 @@ test('extractSessionUsage uses phase inference for unlabeled turns', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════
+// Task 3: Bar-chart formatter
+// ═══════════════════════════════════════════════════════════════════
+
+section('formatReport: bar-chart output');
+
+test('renderBar is exported', () => {
+  assert.strictEqual(typeof costReporter.renderBar, 'function', 'renderBar should be exported');
+});
+
+test('renderBar produces correct bar for 50%', () => {
+  const bar = costReporter.renderBar(0.5, 20);
+  assert.strictEqual(bar.length, 20, `Bar should be 20 chars, got ${bar.length}`);
+  const filled = (bar.match(/\u2588/g) || []).length;
+  assert.strictEqual(filled, 10, `Expected 10 filled blocks, got ${filled}`);
+});
+
+test('renderBar produces all filled for 100%', () => {
+  const bar = costReporter.renderBar(1.0, 20);
+  const filled = (bar.match(/\u2588/g) || []).length;
+  assert.strictEqual(filled, 20);
+});
+
+test('renderBar produces all empty for 0%', () => {
+  const bar = costReporter.renderBar(0, 20);
+  const empty = (bar.match(/\u2591/g) || []).length;
+  assert.strictEqual(empty, 20);
+});
+
+const mockAggregated = {
+  period: '7 days',
+  sessions: [{ id: 's1' }, { id: 's2' }],
+  totals: { totalTokens: 10000, turns: 50 },
+  byActivity: {
+    'skill:review': { turns: 20, totalTokens: 6000, models: {} },
+    'implementation': { turns: 30, totalTokens: 4000, models: {} },
+  },
+  byModel: {
+    'claude-opus-4-6': { turns: 40, totalTokens: 8000 },
+    'claude-sonnet-4-6': { turns: 10, totalTokens: 2000 },
+  },
+  byBranch: {
+    'feature/16-costs': { sessions: 2, totalTokens: 10000 },
+  },
+};
+
+test('formatReport contains BY ACTIVITY section', () => {
+  const report = costReporter.formatReport(mockAggregated);
+  assert.ok(report.includes('BY ACTIVITY'), 'Should contain BY ACTIVITY');
+});
+
+test('formatReport contains bar chart characters', () => {
+  const report = costReporter.formatReport(mockAggregated);
+  assert.ok(report.includes('\u2588'), 'Should contain filled block');
+  assert.ok(report.includes('\u2591'), 'Should contain empty block');
+});
+
+test('formatReport contains percentage', () => {
+  const report = costReporter.formatReport(mockAggregated);
+  assert.ok(report.includes('%'), 'Should contain percentage');
+});
+
+test('formatReport does NOT contain dollar signs', () => {
+  const report = costReporter.formatReport(mockAggregated);
+  assert.ok(!report.includes('$'), 'Should not contain dollar sign');
+});
+
+test('formatReport contains BY MODEL section', () => {
+  const report = costReporter.formatReport(mockAggregated);
+  assert.ok(report.includes('BY MODEL'), 'Should contain BY MODEL');
+});
+
+test('formatReport contains BY BRANCH section', () => {
+  const report = costReporter.formatReport(mockAggregated);
+  assert.ok(report.includes('BY BRANCH'), 'Should contain BY BRANCH');
+});
+
+test('formatReport sorts activities by totalTokens descending', () => {
+  const report = costReporter.formatReport(mockAggregated);
+  const reviewIdx = report.indexOf('skill:review');
+  const implIdx = report.indexOf('implementation');
+  assert.ok(reviewIdx < implIdx, 'skill:review (6000) should appear before implementation (4000)');
+});
+
+// ═══════════════════════════════════════════════════════════════════
 // Summary
 // ═══════════════════════════════════════════════════════════════════
 

--- a/tests/lib/cost-reporter.test.js
+++ b/tests/lib/cost-reporter.test.js
@@ -338,6 +338,75 @@ test('formatReport includes BY PROJECT when byProject data exists', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════
+// Task 6: Team aggregation
+// ═══════════════════════════════════════════════════════════════════
+
+section('aggregateTeamReports: merge JSON files');
+
+test('aggregateTeamReports is exported', () => {
+  assert.strictEqual(typeof costReporter.aggregateTeamReports, 'function');
+});
+
+test('aggregateTeamReports merges multiple JSON files', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'team-reports-'));
+  const reportsDir = path.join(tmpDir, 'docs', 'costs', 'reports');
+  fs.mkdirSync(reportsDir, { recursive: true });
+
+  fs.writeFileSync(path.join(reportsDir, '2026-04-05-alice.json'), JSON.stringify({
+    date: '2026-04-05', user: 'alice', branch: 'main', totalTokens: 3000, turns: 5,
+    activities: { 'skill:review': 2000, 'implementation': 1000 },
+    models: { 'claude-opus-4-6': 3000 },
+  }));
+  fs.writeFileSync(path.join(reportsDir, '2026-04-06-bob.json'), JSON.stringify({
+    date: '2026-04-06', user: 'bob', branch: 'feature/x', totalTokens: 5000, turns: 10,
+    activities: { 'implementation': 4000, 'debugging': 1000 },
+    models: { 'claude-opus-4-6': 3000, 'claude-sonnet-4-6': 2000 },
+  }));
+
+  const result = costReporter.aggregateTeamReports(reportsDir);
+
+  assert.ok(result.byContributor, 'Should have byContributor');
+  assert.strictEqual(result.byContributor['alice'].totalTokens, 3000);
+  assert.strictEqual(result.byContributor['bob'].totalTokens, 5000);
+  assert.strictEqual(result.totals.totalTokens, 8000);
+  assert.strictEqual(result.byActivity['implementation'].totalTokens, 5000);
+
+  cleanup(tmpDir);
+});
+
+test('aggregateTeamReports filters by days', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'team-reports-'));
+  const reportsDir = path.join(tmpDir, 'docs', 'costs', 'reports');
+  fs.mkdirSync(reportsDir, { recursive: true });
+
+  fs.writeFileSync(path.join(reportsDir, '2020-01-01-old.json'), JSON.stringify({
+    date: '2020-01-01', user: 'old', branch: 'main', totalTokens: 9999, turns: 1,
+    activities: {}, models: {},
+  }));
+  fs.writeFileSync(path.join(reportsDir, '2026-04-06-recent.json'), JSON.stringify({
+    date: '2026-04-06', user: 'recent', branch: 'main', totalTokens: 100, turns: 1,
+    activities: {}, models: {},
+  }));
+
+  const result = costReporter.aggregateTeamReports(reportsDir, { days: 7 });
+  assert.strictEqual(result.totals.totalTokens, 100, 'Should only include recent report');
+
+  cleanup(tmpDir);
+});
+
+test('formatReport includes BY CONTRIBUTOR when byContributor exists', () => {
+  const data = {
+    ...mockAggregated,
+    byContributor: {
+      'alice': { totalTokens: 6000 },
+      'bob': { totalTokens: 4000 },
+    },
+  };
+  const report = costReporter.formatReport(data);
+  assert.ok(report.includes('BY CONTRIBUTOR'), 'Should contain BY CONTRIBUTOR section');
+});
+
+// ═══════════════════════════════════════════════════════════════════
 // Summary
 // ═══════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Redesign the cost reporter to focus on actionable token usage visibility rather than approximate dollar estimates. Shows where tokens go — which skills, phases, models, and branches consume the most — using compact bar-chart output.

## Changes

- **Core rework:** Strip all dollar pricing from `lib/cost-reporter.js`, replace with combined token counts
- **Phase inference:** Two-tier activity classification — explicit skill/agent labels + sliding-window tool-pattern inference (implementation, debugging, review, interactive, planning)
- **Bar-chart output:** Replace markdown tables with compact plain-text bar charts sorted by token count
- **Cross-project:** `--all` flag discovers all Claude projects and aggregates with BY PROJECT section
- **Team visibility:** Session-end hook exports summary JSON to `docs/costs/reports/`; `--team` flag aggregates committed reports with BY CONTRIBUTOR section
- **Hook registration:** New `cost-summary-export` hook registered in `hooks.json` and `hook-runner.js`

## Test Plan

- [x] 41 unit tests for cost-reporter (token aggregation, phase inference, bar-chart, cross-project, team aggregation)
- [x] 4 unit tests for cost-summary-export hook
- [x] Zero-division edge case for empty reports
- [x] Team report compatibility with formatReport

## Linked Issue

Closes #16

---

*Created with Envoy*