### PR TITLE
Fix SessionStart hook output shape (#30)

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -154,6 +154,9 @@ ESCAPED_CONTENT=$(escape_json "$OUTPUT_CONTENT")
 # Output JSON response
 cat << EOF
 {
-  "hookSpecificOutput": "$ESCAPED_CONTENT"
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "$ESCAPED_CONTENT"
+  }
 }
 EOF

--- a/tests/hooks/session-start-output.test.js
+++ b/tests/hooks/session-start-output.test.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * SessionStart Hook Output Shape — Test Suite
+ *
+ * Run: node tests/hooks/session-start-output.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const HOOK = path.join(REPO_ROOT, 'hooks', 'session-start.sh');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function runHook() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'session-start-'));
+  const stdout = execFileSync('bash', [HOOK], {
+    cwd,
+    encoding: 'utf8',
+    input: JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup', session_id: 'test', cwd }),
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: REPO_ROOT }
+  });
+  fs.rmSync(cwd, { recursive: true, force: true });
+  return stdout;
+}
+
+test('hook emits valid JSON', () => {
+  const parsed = JSON.parse(runHook());
+  assert.ok(parsed && typeof parsed === 'object');
+});
+
+test('hookSpecificOutput is the required object shape, not a string', () => {
+  const parsed = JSON.parse(runHook());
+  const hso = parsed.hookSpecificOutput;
+  assert.strictEqual(typeof hso, 'object', 'hookSpecificOutput must be an object');
+  assert.ok(!Array.isArray(hso), 'hookSpecificOutput must not be an array');
+  assert.strictEqual(hso.hookEventName, 'SessionStart');
+});
+
+test('additionalContext carries the bootstrap content', () => {
+  const parsed = JSON.parse(runHook());
+  const ctx = parsed.hookSpecificOutput.additionalContext;
+  assert.strictEqual(typeof ctx, 'string');
+  assert.ok(ctx.includes('EXTREMELY_IMPORTANT'), 'bootstrap wrapper must be present');
+  assert.ok(ctx.includes('Envoy'), 'bootstrap must mention Envoy');
+});
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/hooks/session-start-output.test.js
+++ b/tests/hooks/session-start-output.test.js
@@ -30,14 +30,17 @@ function test(name, fn) {
 
 function runHook() {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'session-start-'));
-  const stdout = execFileSync('bash', [HOOK], {
-    cwd,
-    encoding: 'utf8',
-    input: JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup', session_id: 'test', cwd }),
-    env: { ...process.env, CLAUDE_PLUGIN_ROOT: REPO_ROOT }
-  });
-  fs.rmSync(cwd, { recursive: true, force: true });
-  return stdout;
+  try {
+    return execFileSync('bash', [HOOK], {
+      cwd,
+      encoding: 'utf8',
+      timeout: 30000,
+      input: JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup', session_id: 'test', cwd }),
+      env: { ...process.env, CLAUDE_PLUGIN_ROOT: REPO_ROOT }
+    });
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
 }
 
 test('hook emits valid JSON', () => {


### PR DESCRIPTION
## Overview

`hooks/session-start.sh` emitted `hookSpecificOutput` as a bare string; Claude Code requires the nested object (`hookEventName` + `additionalContext`). On CC 2.1.202 the invalid shape fails output validation at every session start — so the using-envoy bootstrap injection (Envoy's primary skill-discovery mechanism) never reached the session.

## Changes
- `hooks/session-start.sh`: wrap the emission in `{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}`
- `tests/hooks/session-start-output.test.js` (TDD, red-first): runs the real script and pins valid JSON, the nested object shape, and bootstrap content in `additionalContext`

## Testing
- New tests: 3/3 pass (were 1/3 before the fix)
- Full suite: passes except the pre-existing date-stale `tests/lib/cost-reporter.test.js` fixture on main — that fix ships in #29, unrelated to this change

Closes #30. Same bug family as the #28 findings on #26.
