### PR TITLE
docs: cross-platform Chrome launch instructions for visual review

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,15 +502,18 @@ Chrome DevTools MCP enables visual verification by capturing screenshots, consol
 
    # Linux
    google-chrome --remote-debugging-port=9222
+   ```
 
-   # Windows (PowerShell)
+   ```powershell
+   # Windows
    & "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
    ```
 
-   On a headless box (server / CI / remote dev VM) add `--headless=new --no-sandbox`:
+   On a headless box (server / remote dev VM) add `--headless=new`:
    ```bash
-   google-chrome --headless=new --no-sandbox --remote-debugging-port=9222
+   google-chrome --headless=new --remote-debugging-port=9222
    ```
+   If Chrome refuses to start in a container or CI sandbox you trust, add `--no-sandbox` — it disables Chrome's sandbox, so use it only in isolated, trusted environments.
 
 **Without DevTools MCP**: The review skill skips visual verification (Layer 3) and continues with other layers.
 

--- a/README.md
+++ b/README.md
@@ -500,8 +500,16 @@ Chrome DevTools MCP enables visual verification by capturing screenshots, consol
    # macOS
    /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
 
-   # Or create an alias
-   alias chrome-debug='/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222'
+   # Linux
+   google-chrome --remote-debugging-port=9222
+
+   # Windows (PowerShell)
+   & "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+   ```
+
+   On a headless box (server / CI / remote dev VM) add `--headless=new --no-sandbox`:
+   ```bash
+   google-chrome --headless=new --no-sandbox --remote-debugging-port=9222
    ```
 
 **Without DevTools MCP**: The review skill skips visual verification (Layer 3) and continues with other layers.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -60,16 +60,20 @@ Launch Chrome with debugging:
 
 # Linux
 google-chrome --remote-debugging-port=9222
+```
 
-# Windows (PowerShell)
+```powershell
+# Windows
 & "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
 ```
 
-On a headless box (server / CI / remote dev VM) add `--headless=new --no-sandbox`:
+On a headless box (server / remote dev VM) add `--headless=new`:
 
 ```bash
-google-chrome --headless=new --no-sandbox --remote-debugging-port=9222
+google-chrome --headless=new --remote-debugging-port=9222
 ```
+
+If Chrome refuses to start in a container or CI sandbox you trust, add `--no-sandbox` — it disables Chrome's sandbox, so use it only in isolated, trusted environments.
 
 ### Verify Setup
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -55,7 +55,20 @@ Add to `~/.mcp.json`:
 Launch Chrome with debugging:
 
 ```bash
+# macOS
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+
+# Linux
+google-chrome --remote-debugging-port=9222
+
+# Windows (PowerShell)
+& "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+```
+
+On a headless box (server / CI / remote dev VM) add `--headless=new --no-sandbox`:
+
+```bash
+google-chrome --headless=new --no-sandbox --remote-debugging-port=9222
 ```
 
 ### Verify Setup


### PR DESCRIPTION
## Overview

Rescues finished-but-never-committed work found sitting in the main checkout's working tree (on the otherwise-empty `fix/visual-review-chrome-path-cross-platform` branch): cross-platform Chrome remote-debugging launch instructions (macOS / Linux / Windows PowerShell, plus headless flags for server/CI boxes) for README and the Getting-Started wiki page.

Docs only — no code changes. Found during branch cleanup.
