### PR TITLE
pr-status snapshot engine + route finalize CodeRabbit poll through it (closes #25) (#36)

### DIFF
--- a/lib/pr-status.js
+++ b/lib/pr-status.js
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// ABOUTME: Produces one schema-stable JSON snapshot of a PR's status (CI, CodeRabbit, reviewers, idle).
+// ABOUTME: Parsing/counting is pure and unit-tested; gh/GraphQL fetch lives in thin wrappers kept out of tests.
+
+const { execFileSync } = require('child_process');
+
+// ═══════════════════════════════════════════════════════════════════
+// Pure functions (unit-tested with fixtures — no network)
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Parse a CodeRabbit "rate limit exceeded" comment body.
+ *
+ * Detects the rate-limit marker, then resolves the reset time from either an
+ * absolute ISO timestamp in the body or a relative "N minutes [and M seconds]"
+ * phrase measured from `now`.
+ *
+ * @param {string} body - Comment body text
+ * @param {Date} [now] - Reference time for relative resets (defaults to current time)
+ * @returns {{ rateLimited: boolean, resetsAt: string|null }} ISO reset time or null
+ */
+function parseRateLimit(body, now = new Date()) {
+  if (!body || !/rate limit exceeded/i.test(body)) {
+    return { rateLimited: false, resetsAt: null };
+  }
+
+  // Absolute ISO timestamp takes precedence when present.
+  const isoMatch = body.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/);
+  if (isoMatch) {
+    const parsed = new Date(isoMatch[0]);
+    if (!Number.isNaN(parsed.getTime())) {
+      return { rateLimited: true, resetsAt: parsed.toISOString() };
+    }
+  }
+
+  // Relative "N minutes [and M seconds]".
+  const relMatch = body.match(/(\d+)\s*minutes?(?:\s*and\s*(\d+)\s*seconds?)?/i);
+  if (relMatch) {
+    const minutes = parseInt(relMatch[1], 10);
+    const seconds = relMatch[2] ? parseInt(relMatch[2], 10) : 0;
+    const resetsAt = new Date(now.getTime() + (minutes * 60 + seconds) * 1000);
+    return { rateLimited: true, resetsAt: resetsAt.toISOString() };
+  }
+
+  return { rateLimited: true, resetsAt: null };
+}
+
+/**
+ * Count unresolved CodeRabbit review threads from a GraphQL reviewThreads payload.
+ *
+ * A thread counts when its first comment's author login contains "coderabbit"
+ * (case-insensitive) AND the thread is not resolved. This is the #25 fix — REST
+ * comment counts miss CodeRabbit inline threads, so the count MUST come from
+ * GraphQL reviewThreads.
+ *
+ * @param {{nodes: object[]}|object[]} payload - reviewThreads object or its nodes array
+ * @returns {number} Count of unresolved CodeRabbit threads
+ */
+function countUnresolvedThreads(payload) {
+  if (!payload) return 0;
+  const nodes = Array.isArray(payload) ? payload : payload.nodes;
+  if (!Array.isArray(nodes)) return 0;
+
+  return nodes.filter((threadNode) => {
+    if (!threadNode || threadNode.isResolved !== false) return false;
+    const comments = threadNode.comments && threadNode.comments.nodes;
+    if (!Array.isArray(comments) || comments.length === 0) return false;
+    const login = comments[0].author && comments[0].author.login;
+    return typeof login === 'string' && login.toLowerCase().includes('coderabbit');
+  }).length;
+}
+
+/**
+ * Whole minutes elapsed between `lastActivityAt` and `now`.
+ *
+ * @param {string|null} lastActivityAt - ISO timestamp of last PR activity
+ * @param {Date} now - Reference time
+ * @returns {number|null} Idle minutes, or null when lastActivityAt is absent/invalid
+ */
+function idleMinutesSince(lastActivityAt, now) {
+  if (!lastActivityAt) return null;
+  const then = new Date(lastActivityAt);
+  if (Number.isNaN(then.getTime())) return null;
+  return Math.floor((now.getTime() - then.getTime()) / 60000);
+}
+
+/**
+ * Assemble the schema-stable PR status snapshot from already-fetched raw inputs.
+ *
+ * @param {object} raw - Fetched inputs
+ * @param {number} raw.pr - PR number
+ * @param {{state: string, checks: object[]}} raw.ci - CI rollup state and checks
+ * @param {string} raw.coderabbitCheckState - CodeRabbit check run state
+ * @param {{nodes: object[]}|object[]} raw.reviewThreads - GraphQL reviewThreads payload
+ * @param {string|null} raw.rateLimitCommentBody - CodeRabbit rate-limit comment body, if any
+ * @param {object[]} raw.reviewers - Reviewer review states
+ * @param {string|null} raw.lastActivityAt - ISO timestamp of last activity
+ * @param {Date} [raw.now] - Reference time (defaults to current time)
+ * @returns {object} Snapshot with { pr, ci, coderabbit, reviewers, idle }
+ */
+function buildSnapshot(raw) {
+  const now = raw.now || new Date();
+  return {
+    pr: raw.pr,
+    ci: {
+      state: raw.ci ? raw.ci.state : null,
+      checks: (raw.ci && raw.ci.checks) || [],
+    },
+    coderabbit: {
+      checkState: raw.coderabbitCheckState || null,
+      unresolvedThreads: countUnresolvedThreads(raw.reviewThreads),
+      rateLimit: parseRateLimit(raw.rateLimitCommentBody, now),
+    },
+    reviewers: raw.reviewers || [],
+    idle: {
+      lastActivityAt: raw.lastActivityAt || null,
+      idleMinutes: idleMinutesSince(raw.lastActivityAt, now),
+    },
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Thin gh/GraphQL wrappers (NOT unit-tested — live network)
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Run gh and return parsed JSON stdout.
+ * @param {string[]} args - Arguments passed to gh
+ * @returns {any} Parsed JSON
+ */
+function ghJson(args) {
+  const out = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 });
+  return JSON.parse(out);
+}
+
+/**
+ * Resolve the current repository's owner and name via gh.
+ * @returns {{owner: string, repo: string}}
+ */
+function currentRepo() {
+  const data = ghJson(['repo', 'view', '--json', 'owner,name']);
+  return { owner: data.owner.login, repo: data.name };
+}
+
+/**
+ * Fetch CI rollup, reviewers, and last-activity timestamp for a PR.
+ * @param {number} prNumber
+ * @returns {object}
+ */
+function fetchPrView(prNumber) {
+  return ghJson([
+    'pr', 'view', String(prNumber),
+    '--json', 'number,statusCheckRollup,reviews,updatedAt,latestReviews',
+  ]);
+}
+
+/**
+ * Fetch reviewThreads via GraphQL — the authoritative source for unresolved
+ * CodeRabbit inline threads (REST misses them, #25).
+ * @param {{owner: string, repo: string}} repo
+ * @param {number} prNumber
+ * @returns {{nodes: object[]}}
+ */
+function fetchReviewThreads(repo, prNumber) {
+  const query = [
+    'query($owner:String!,$repo:String!,$pr:Int!){',
+    '  repository(owner:$owner,name:$repo){',
+    '    pullRequest(number:$pr){',
+    '      reviewThreads(first:100){',
+    '        nodes{ isResolved comments(first:1){ nodes{ author{ login } } } }',
+    '      }',
+    '    }',
+    '  }',
+    '}',
+  ].join('\n');
+  const data = ghJson([
+    'api', 'graphql',
+    '-f', `query=${query}`,
+    '-F', `owner=${repo.owner}`,
+    '-F', `repo=${repo.repo}`,
+    '-F', `pr=${prNumber}`,
+  ]);
+  return data.data.repository.pullRequest.reviewThreads;
+}
+
+/**
+ * Fetch the latest CodeRabbit rate-limit comment body, if any.
+ * @param {number} prNumber
+ * @returns {string|null}
+ */
+function fetchRateLimitCommentBody(prNumber) {
+  const data = ghJson(['pr', 'view', String(prNumber), '--json', 'comments']);
+  const comments = (data.comments || []).filter((c) => {
+    const login = (c.author && (c.author.login || c.author.name)) || '';
+    return login.toLowerCase().includes('coderabbit');
+  });
+  for (let i = comments.length - 1; i >= 0; i--) {
+    if (/rate limit exceeded/i.test(comments[i].body || '')) {
+      return comments[i].body;
+    }
+  }
+  return null;
+}
+
+/**
+ * Derive CI state and per-check list from a statusCheckRollup, and pull out
+ * CodeRabbit's own check state.
+ * @param {object[]} rollup - statusCheckRollup nodes from gh pr view
+ * @returns {{ci: {state: string, checks: object[]}, coderabbitCheckState: string|null}}
+ */
+function summarizeChecks(rollup) {
+  const nodes = rollup || [];
+  const checks = nodes.map((n) => ({
+    name: n.name || n.context || 'unknown',
+    state: n.conclusion || n.state || n.status || null,
+  }));
+  let state = 'SUCCESS';
+  for (const c of checks) {
+    const s = (c.state || '').toUpperCase();
+    if (s === 'FAILURE' || s === 'ERROR' || s === 'TIMED_OUT' || s === 'CANCELLED' || s === 'ACTION_REQUIRED') {
+      state = 'FAILURE';
+      break;
+    }
+    if (s === 'PENDING' || s === 'IN_PROGRESS' || s === 'QUEUED' || s === '') {
+      state = 'PENDING';
+    }
+  }
+  if (checks.length === 0) state = 'NONE';
+
+  const crCheck = checks.find((c) => /coderabbit/i.test(c.name));
+  return { ci: { state, checks }, coderabbitCheckState: crCheck ? crCheck.state : null };
+}
+
+/**
+ * Fetch all raw inputs for a PR and assemble the snapshot.
+ * @param {number} prNumber
+ * @returns {object} Snapshot
+ */
+function getSnapshot(prNumber) {
+  const repo = currentRepo();
+  const view = fetchPrView(prNumber);
+  const { ci, coderabbitCheckState } = summarizeChecks(view.statusCheckRollup);
+  const reviewThreads = fetchReviewThreads(repo, prNumber);
+  const rateLimitCommentBody = fetchRateLimitCommentBody(prNumber);
+  const reviewers = (view.latestReviews || view.reviews || []).map((r) => ({
+    login: r.author ? r.author.login : null,
+    state: r.state,
+  }));
+
+  return buildSnapshot({
+    pr: view.number || prNumber,
+    ci,
+    coderabbitCheckState,
+    reviewThreads,
+    rateLimitCommentBody,
+    reviewers,
+    lastActivityAt: view.updatedAt || null,
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// CLI entrypoint
+// ═══════════════════════════════════════════════════════════════════
+
+function main() {
+  const prNumber = parseInt(process.argv[2], 10);
+  if (!prNumber) {
+    process.stderr.write('Usage: node lib/pr-status.js <pr-number>\n');
+    process.exit(1);
+  }
+  const snapshot = getSnapshot(prNumber);
+  process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  parseRateLimit,
+  countUnresolvedThreads,
+  idleMinutesSince,
+  buildSnapshot,
+  summarizeChecks,
+  getSnapshot,
+};

--- a/lib/pr-status.js
+++ b/lib/pr-status.js
@@ -125,6 +125,35 @@ function buildSnapshot(raw) {
   };
 }
 
+/**
+ * Derive CI state and per-check list from a statusCheckRollup, and pull out
+ * CodeRabbit's own check state.
+ * @param {object[]} rollup - statusCheckRollup nodes from gh pr view
+ * @returns {{ci: {state: string, checks: object[]}, coderabbitCheckState: string|null}}
+ */
+function summarizeChecks(rollup) {
+  const nodes = rollup || [];
+  const checks = nodes.map((n) => ({
+    name: n.name || n.context || 'unknown',
+    state: n.conclusion || n.state || n.status || null,
+  }));
+  let state = 'SUCCESS';
+  for (const c of checks) {
+    const s = (c.state || '').toUpperCase();
+    if (s === 'FAILURE' || s === 'ERROR' || s === 'TIMED_OUT' || s === 'CANCELLED' || s === 'ACTION_REQUIRED') {
+      state = 'FAILURE';
+      break;
+    }
+    if (s === 'PENDING' || s === 'IN_PROGRESS' || s === 'QUEUED' || s === '') {
+      state = 'PENDING';
+    }
+  }
+  if (checks.length === 0) state = 'NONE';
+
+  const crCheck = checks.find((c) => /coderabbit/i.test(c.name));
+  return { ci: { state, checks }, coderabbitCheckState: crCheck ? crCheck.state : null };
+}
+
 // ═══════════════════════════════════════════════════════════════════
 // Thin gh/GraphQL wrappers (NOT unit-tested — live network)
 // ═══════════════════════════════════════════════════════════════════
@@ -206,35 +235,6 @@ function fetchRateLimitCommentBody(prNumber) {
     }
   }
   return null;
-}
-
-/**
- * Derive CI state and per-check list from a statusCheckRollup, and pull out
- * CodeRabbit's own check state.
- * @param {object[]} rollup - statusCheckRollup nodes from gh pr view
- * @returns {{ci: {state: string, checks: object[]}, coderabbitCheckState: string|null}}
- */
-function summarizeChecks(rollup) {
-  const nodes = rollup || [];
-  const checks = nodes.map((n) => ({
-    name: n.name || n.context || 'unknown',
-    state: n.conclusion || n.state || n.status || null,
-  }));
-  let state = 'SUCCESS';
-  for (const c of checks) {
-    const s = (c.state || '').toUpperCase();
-    if (s === 'FAILURE' || s === 'ERROR' || s === 'TIMED_OUT' || s === 'CANCELLED' || s === 'ACTION_REQUIRED') {
-      state = 'FAILURE';
-      break;
-    }
-    if (s === 'PENDING' || s === 'IN_PROGRESS' || s === 'QUEUED' || s === '') {
-      state = 'PENDING';
-    }
-  }
-  if (checks.length === 0) state = 'NONE';
-
-  const crCheck = checks.find((c) => /coderabbit/i.test(c.name));
-  return { ci: { state, checks }, coderabbitCheckState: crCheck ? crCheck.state : null };
 }
 
 /**

--- a/lib/pr-status.js
+++ b/lib/pr-status.js
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
-// ABOUTME: Produces one schema-stable JSON snapshot of a PR's status (CI, CodeRabbit, reviewers, idle).
-// ABOUTME: Parsing/counting is pure and unit-tested; gh/GraphQL fetch lives in thin wrappers kept out of tests.
+/**
+ * PR status snapshot engine.
+ *
+ * Produces one schema-stable JSON snapshot of a PR's status: CI, CodeRabbit
+ * (check state, unresolved review threads via GraphQL, rate-limit), reviewers, idle.
+ * Parsing/counting is pure and unit-tested; gh/GraphQL fetch lives in thin
+ * wrappers kept out of the tests.
+ */
 
 const { execFileSync } = require('child_process');
 

--- a/skills/finalize/steps/coderabbit.md
+++ b/skills/finalize/steps/coderabbit.md
@@ -142,15 +142,19 @@ PR_NUMBER=$(jq -r .prNumber .envoy/finalize/state.json)
 PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
 # Probe is non-fatal: a pr-status failure must not abort the step under set -e/pipefail.
 SNAP=$($PR_STATUS "$PR_NUMBER" 2>/dev/null || true)
-UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty' 2>/dev/null)
-RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited // empty' 2>/dev/null)
 
-# A missing snapshot (empty UNRESOLVED) means the status probe failed — do NOT
-# treat that as a clean review; reset the counter and re-poll.
-if [ -n "$UNRESOLVED" ] && [ "$RATE_LIMITED" != "true" ] && [ "$UNRESOLVED" -eq 0 ]; then
-  echo "ENVOY_LOOP_COMPLETE — no unresolved CodeRabbit threads (check N/3)"
+# A missing snapshot means the status probe failed — do NOT treat that as a clean
+# review. Check before jq (same guard as Step 3) so jq never runs on empty input.
+if [ -z "$SNAP" ]; then
+  echo "CodeRabbit status unavailable — reset completion counter"
 else
-  echo "Unresolved CodeRabbit threads: ${UNRESOLVED:-unknown} (rate-limited: ${RATE_LIMITED:-unknown}) — reset completion counter"
+  UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty')
+  RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited // empty')
+  if [ -n "$UNRESOLVED" ] && [ "$RATE_LIMITED" != "true" ] && [ "$UNRESOLVED" -eq 0 ]; then
+    echo "ENVOY_LOOP_COMPLETE — no unresolved CodeRabbit threads (check N/3)"
+  else
+    echo "Unresolved CodeRabbit threads: ${UNRESOLVED:-unknown} (rate-limited: ${RATE_LIMITED:-unknown}) — reset completion counter"
+  fi
 fi
 ```
 

--- a/skills/finalize/steps/coderabbit.md
+++ b/skills/finalize/steps/coderabbit.md
@@ -22,18 +22,21 @@ for WAIT in 120 120 240 360 480; do
   sleep $WAIT
   ELAPSED=$((ELAPSED + WAIT))
 
-  SNAP=$($PR_STATUS "$PR_NUMBER")
-  CR_STATE=$(echo "$SNAP" | jq -r '.coderabbit.checkState // empty')
-  UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty')
-  RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited // empty')
-  RESETS_AT=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.resetsAt // empty')
+  # Probe is non-fatal: a pr-status failure must not abort the step under set -e/pipefail.
+  SNAP=$($PR_STATUS "$PR_NUMBER" 2>/dev/null || true)
 
   # A missing snapshot (status probe failed) — keep polling, don't misread as clean.
-  if [ -z "$UNRESOLVED" ]; then
+  # Check before jq so jq never runs on empty input.
+  if [ -z "$SNAP" ]; then
     echo "CodeRabbit status unavailable. $((ELAPSED / 60))min elapsed; retrying..."
     if [ "$ELAPSED" -ge 1320 ]; then break; fi
     continue
   fi
+
+  CR_STATE=$(echo "$SNAP" | jq -r '.coderabbit.checkState // empty')
+  UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty')
+  RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited // empty')
+  RESETS_AT=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.resetsAt // empty')
 
   # A rate-limited review is NOT a clean review — keep waiting past the reset.
   if [ "$RATE_LIMITED" = "true" ]; then
@@ -137,9 +140,10 @@ A settled review — not rate-limited AND zero unresolved CodeRabbit threads —
 # Each step is a separate shell invocation — re-derive PR_NUMBER and PR_STATUS here.
 PR_NUMBER=$(jq -r .prNumber .envoy/finalize/state.json)
 PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
-SNAP=$($PR_STATUS "$PR_NUMBER")
-UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty')
-RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited // empty')
+# Probe is non-fatal: a pr-status failure must not abort the step under set -e/pipefail.
+SNAP=$($PR_STATUS "$PR_NUMBER" 2>/dev/null || true)
+UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty' 2>/dev/null)
+RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited // empty' 2>/dev/null)
 
 # A missing snapshot (empty UNRESOLVED) means the status probe failed — do NOT
 # treat that as a clean review; reset the counter and re-poll.

--- a/skills/finalize/steps/coderabbit.md
+++ b/skills/finalize/steps/coderabbit.md
@@ -23,10 +23,17 @@ for WAIT in 120 120 240 360 480; do
   ELAPSED=$((ELAPSED + WAIT))
 
   SNAP=$($PR_STATUS "$PR_NUMBER")
-  CR_STATE=$(echo "$SNAP" | jq -r '.coderabbit.checkState')
-  UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads')
-  RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited')
-  RESETS_AT=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.resetsAt')
+  CR_STATE=$(echo "$SNAP" | jq -r '.coderabbit.checkState // empty')
+  UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty')
+  RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited // empty')
+  RESETS_AT=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.resetsAt // empty')
+
+  # A missing snapshot (status probe failed) — keep polling, don't misread as clean.
+  if [ -z "$UNRESOLVED" ]; then
+    echo "CodeRabbit status unavailable. $((ELAPSED / 60))min elapsed; retrying..."
+    if [ "$ELAPSED" -ge 1320 ]; then break; fi
+    continue
+  fi
 
   # A rate-limited review is NOT a clean review — keep waiting past the reset.
   if [ "$RATE_LIMITED" = "true" ]; then
@@ -43,8 +50,8 @@ for WAIT in 120 120 240 360 480; do
 
   # Terminal CodeRabbit check with zero unresolved threads — clean review.
   case "$CR_STATE" in
-    SUCCESS|FAILURE|COMPLETED|NEUTRAL|SKIPPED)
-      echo "CodeRabbit review complete, no unresolved threads after $((ELAPSED / 60))min."
+    SUCCESS|FAILURE|COMPLETED|NEUTRAL|SKIPPED|CANCELLED|TIMED_OUT|ACTION_REQUIRED)
+      echo "CodeRabbit review settled ($CR_STATE), no unresolved threads after $((ELAPSED / 60))min."
       break
       ;;
   esac
@@ -120,37 +127,39 @@ git push
 
 ### Step 7: Re-poll (Max 3 Cycles, with Completion Signal)
 
-Announce: `Running Step 7: Re-poll for new comments...`
+Announce: `Running Step 7: Re-poll for unresolved threads...`
 
-After pushing, CodeRabbit may leave new comments on the fixes. Use the **completion signal pattern** (inline):
+After pushing, CodeRabbit may open new review threads on the fixes. Use the **completion signal pattern** (inline):
 
-"No new comments" must be confirmed 3 consecutive times before the loop stops — a single check could miss comments still being posted. Output `ENVOY_LOOP_COMPLETE` on each clean check; reset the counter when new comments appear.
+A settled review — not rate-limited AND zero unresolved CodeRabbit threads — must be confirmed 3 consecutive times before the loop stops; a single check could miss threads still being posted. Output `ENVOY_LOOP_COMPLETE` on each settled check; reset the counter when threads remain unresolved (or the status is rate-limited/unavailable).
 
 ```bash
+# Each step is a separate shell invocation — re-derive PR_NUMBER and PR_STATUS here.
+PR_NUMBER=$(jq -r .prNumber .envoy/finalize/state.json)
 PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
 SNAP=$($PR_STATUS "$PR_NUMBER")
-UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads')
-RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited')
+UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty')
+RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited // empty')
 
-# Completion requires a settled review: not rate-limited AND zero unresolved
-# CodeRabbit threads (GraphQL reviewThreads, not a REST comment count).
-if [ "$RATE_LIMITED" != "true" ] && [ "$UNRESOLVED" -eq 0 ]; then
+# A missing snapshot (empty UNRESOLVED) means the status probe failed — do NOT
+# treat that as a clean review; reset the counter and re-poll.
+if [ -n "$UNRESOLVED" ] && [ "$RATE_LIMITED" != "true" ] && [ "$UNRESOLVED" -eq 0 ]; then
   echo "ENVOY_LOOP_COMPLETE — no unresolved CodeRabbit threads (check N/3)"
 else
-  echo "Unresolved CodeRabbit threads: $UNRESOLVED (rate-limited: $RATE_LIMITED) — reset completion counter"
+  echo "Unresolved CodeRabbit threads: ${UNRESOLVED:-unknown} (rate-limited: ${RATE_LIMITED:-unknown}) — reset completion counter"
 fi
 ```
 
-**If new comments:** address -> reply -> resolve -> push -> re-poll. Reset completion counter.
+**If threads remain unresolved:** address -> reply -> resolve -> push -> re-poll. Reset completion counter.
 
 **Max 3 address-and-push cycles.** After 3 cycles with remaining issues:
 
 ```
 **Escalation: CodeRabbit cycle limit reached**
 
-After 3 cycles, these comments remain unresolved:
-- <comment 1>
-- <comment 2>
+After 3 cycles, these threads remain unresolved:
+- <thread 1>
+- <thread 2>
 
 Please review and decide how to proceed.
 ```

--- a/skills/finalize/steps/coderabbit.md
+++ b/skills/finalize/steps/coderabbit.md
@@ -10,6 +10,10 @@ GitHub CodeRabbit App reviews the PR asynchronously. Poll with exponential backo
 # CodeRabbit: 22min max (async review — GitHub App processes PR asynchronously)
 PR_NUMBER=$(jq -r .prNumber .envoy/finalize/state.json)
 
+# One snapshot source for the CodeRabbit signal: GraphQL unresolved review
+# threads (REST comment counts miss inline threads, #25) plus rate-limit state.
+PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
+
 # Exponential backoff in seconds — 22min (1320s) max
 # intervals = [120s, 120s, 240s, 360s, 480s]
 # cumulative =  2     4     8    14    22 min
@@ -18,15 +22,34 @@ for WAIT in 120 120 240 360 480; do
   sleep $WAIT
   ELAPSED=$((ELAPSED + WAIT))
 
-  COMMENTS=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-    --jq '[.[] | select(.user.login == "coderabbitai")] | length')
+  SNAP=$($PR_STATUS "$PR_NUMBER")
+  CR_STATE=$(echo "$SNAP" | jq -r '.coderabbit.checkState')
+  UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads')
+  RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited')
+  RESETS_AT=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.resetsAt')
 
-  if [ "$COMMENTS" -gt 0 ]; then
-    echo "CodeRabbit left $COMMENTS comments after $((ELAPSED / 60))min. Addressing..."
+  # A rate-limited review is NOT a clean review — keep waiting past the reset.
+  if [ "$RATE_LIMITED" = "true" ]; then
+    echo "CodeRabbit is rate-limited (resets $RESETS_AT). $((ELAPSED / 60))min elapsed; waiting..."
+    if [ "$ELAPSED" -ge 1320 ]; then break; fi
+    continue
+  fi
+
+  # Unresolved CodeRabbit threads present — go address them.
+  if [ "$UNRESOLVED" -gt 0 ]; then
+    echo "CodeRabbit left $UNRESOLVED unresolved thread(s) after $((ELAPSED / 60))min. Addressing..."
     break
   fi
 
-  echo "No CodeRabbit comments yet. $((ELAPSED / 60))min elapsed."
+  # Terminal CodeRabbit check with zero unresolved threads — clean review.
+  case "$CR_STATE" in
+    SUCCESS|FAILURE|COMPLETED|NEUTRAL|SKIPPED)
+      echo "CodeRabbit review complete, no unresolved threads after $((ELAPSED / 60))min."
+      break
+      ;;
+  esac
+
+  echo "CodeRabbit review still pending. $((ELAPSED / 60))min elapsed."
   if [ "$ELAPSED" -ge 1320 ]; then break; fi
 done
 ```
@@ -104,14 +127,17 @@ After pushing, CodeRabbit may leave new comments on the fixes. Use the **complet
 "No new comments" must be confirmed 3 consecutive times before the loop stops — a single check could miss comments still being posted. Output `ENVOY_LOOP_COMPLETE` on each clean check; reset the counter when new comments appear.
 
 ```bash
-LAST_PUSH=$(git log -1 --format=%cI)
-NEW_COMMENTS=$(gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-  --jq "[.[] | select(.user.login == \"coderabbitai\") | select(.created_at > \"$LAST_PUSH\")] | length")
+PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
+SNAP=$($PR_STATUS "$PR_NUMBER")
+UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads')
+RATE_LIMITED=$(echo "$SNAP" | jq -r '.coderabbit.rateLimit.rateLimited')
 
-if [ "$NEW_COMMENTS" -eq 0 ]; then
-  echo "ENVOY_LOOP_COMPLETE — no new comments (check N/3)"
+# Completion requires a settled review: not rate-limited AND zero unresolved
+# CodeRabbit threads (GraphQL reviewThreads, not a REST comment count).
+if [ "$RATE_LIMITED" != "true" ] && [ "$UNRESOLVED" -eq 0 ]; then
+  echo "ENVOY_LOOP_COMPLETE — no unresolved CodeRabbit threads (check N/3)"
 else
-  echo "New comments found: $NEW_COMMENTS — reset completion counter"
+  echo "Unresolved CodeRabbit threads: $UNRESOLVED (rate-limited: $RATE_LIMITED) — reset completion counter"
 fi
 ```
 

--- a/tests/lib/pr-status.test.js
+++ b/tests/lib/pr-status.test.js
@@ -193,6 +193,73 @@ test('missing lastActivityAt yields null idleMinutes', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════
+// summarizeChecks
+// ═══════════════════════════════════════════════════════════════════
+
+section('summarizeChecks: CI rollup state + CodeRabbit check derivation');
+
+test('empty rollup yields NONE state, no checks, null CodeRabbit state', () => {
+  const result = prStatus.summarizeChecks([]);
+  assert.strictEqual(result.ci.state, 'NONE');
+  assert.deepStrictEqual(result.ci.checks, []);
+  assert.strictEqual(result.coderabbitCheckState, null);
+});
+
+test('missing rollup (undefined) is treated as empty', () => {
+  const result = prStatus.summarizeChecks(undefined);
+  assert.strictEqual(result.ci.state, 'NONE');
+  assert.strictEqual(result.coderabbitCheckState, null);
+});
+
+test('all-success checks yield SUCCESS', () => {
+  const result = prStatus.summarizeChecks([
+    { name: 'test', conclusion: 'SUCCESS' },
+    { name: 'build', conclusion: 'SUCCESS' },
+  ]);
+  assert.strictEqual(result.ci.state, 'SUCCESS');
+});
+
+test('any failing check yields FAILURE (precedence over pending)', () => {
+  const result = prStatus.summarizeChecks([
+    { name: 'a', conclusion: 'PENDING' },
+    { name: 'b', conclusion: 'FAILURE' },
+    { name: 'c', conclusion: 'SUCCESS' },
+  ]);
+  assert.strictEqual(result.ci.state, 'FAILURE');
+});
+
+test('pending without failure yields PENDING', () => {
+  const result = prStatus.summarizeChecks([
+    { name: 'a', conclusion: 'SUCCESS' },
+    { name: 'b', status: 'IN_PROGRESS' },
+  ]);
+  assert.strictEqual(result.ci.state, 'PENDING');
+});
+
+test('name falls back context→unknown; state falls back conclusion→state→status→null', () => {
+  const result = prStatus.summarizeChecks([
+    { context: 'legacy-status', state: 'SUCCESS' },
+    { conclusion: 'SUCCESS' },
+  ]);
+  assert.strictEqual(result.ci.checks[0].name, 'legacy-status');
+  assert.strictEqual(result.ci.checks[1].name, 'unknown');
+  assert.strictEqual(result.ci.checks[0].state, 'SUCCESS');
+});
+
+test('CodeRabbit check state is picked out by name (case-insensitive)', () => {
+  const result = prStatus.summarizeChecks([
+    { name: 'CI', conclusion: 'SUCCESS' },
+    { name: 'CodeRabbit', conclusion: 'NEUTRAL' },
+  ]);
+  assert.strictEqual(result.coderabbitCheckState, 'NEUTRAL');
+});
+
+test('no CodeRabbit check yields null coderabbitCheckState', () => {
+  const result = prStatus.summarizeChecks([{ name: 'CI', conclusion: 'SUCCESS' }]);
+  assert.strictEqual(result.coderabbitCheckState, null);
+});
+
+// ═══════════════════════════════════════════════════════════════════
 // Summary
 // ═══════════════════════════════════════════════════════════════════
 

--- a/tests/lib/pr-status.test.js
+++ b/tests/lib/pr-status.test.js
@@ -35,10 +35,6 @@ function section(name) {
 
 section('parseRateLimit: CodeRabbit rate-limit comment bodies');
 
-test('parseRateLimit is exported', () => {
-  assert.strictEqual(typeof prStatus.parseRateLimit, 'function');
-});
-
 test('non-rate-limit body returns not rate-limited, null reset', () => {
   const result = prStatus.parseRateLimit('Actionable comments posted: 3\n\nLooks good overall.');
   assert.deepStrictEqual(result, { rateLimited: false, resetsAt: null });
@@ -93,10 +89,6 @@ test('rate-limit body with no parseable reset returns rateLimited true, null res
 
 section('countUnresolvedThreads: GraphQL reviewThreads filtered to CodeRabbit + unresolved');
 
-test('countUnresolvedThreads is exported', () => {
-  assert.strictEqual(typeof prStatus.countUnresolvedThreads, 'function');
-});
-
 function thread(login, isResolved) {
   return {
     isResolved,
@@ -139,10 +131,6 @@ test('thread with no comments is ignored', () => {
 // ═══════════════════════════════════════════════════════════════════
 
 section('buildSnapshot: schema-stable assembly from raw inputs');
-
-test('buildSnapshot is exported', () => {
-  assert.strictEqual(typeof prStatus.buildSnapshot, 'function');
-});
 
 const rawInputs = {
   pr: 42,

--- a/tests/lib/pr-status.test.js
+++ b/tests/lib/pr-status.test.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
-// ABOUTME: Test suite for lib/pr-status.js pure functions.
-// ABOUTME: Fixture-based, no network — covers rate-limit parse, thread counting, snapshot assembly.
+/**
+ * PR status snapshot engine — Test Suite
+ *
+ * Fixture-based, no network — covers rate-limit parse, thread counting, snapshot assembly.
+ * Run: node tests/lib/pr-status.test.js
+ */
 
 const assert = require('assert');
 const path = require('path');

--- a/tests/lib/pr-status.test.js
+++ b/tests/lib/pr-status.test.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+// ABOUTME: Test suite for lib/pr-status.js pure functions.
+// ABOUTME: Fixture-based, no network — covers rate-limit parse, thread counting, snapshot assembly.
+
+const assert = require('assert');
+const path = require('path');
+
+const prStatus = require(path.join(__dirname, '..', '..', 'lib', 'pr-status.js'));
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// parseRateLimit
+// ═══════════════════════════════════════════════════════════════════
+
+section('parseRateLimit: CodeRabbit rate-limit comment bodies');
+
+test('parseRateLimit is exported', () => {
+  assert.strictEqual(typeof prStatus.parseRateLimit, 'function');
+});
+
+test('non-rate-limit body returns not rate-limited, null reset', () => {
+  const result = prStatus.parseRateLimit('Actionable comments posted: 3\n\nLooks good overall.');
+  assert.deepStrictEqual(result, { rateLimited: false, resetsAt: null });
+});
+
+test('empty / null body returns not rate-limited', () => {
+  assert.deepStrictEqual(prStatus.parseRateLimit(''), { rateLimited: false, resetsAt: null });
+  assert.deepStrictEqual(prStatus.parseRateLimit(null), { rateLimited: false, resetsAt: null });
+});
+
+test('relative "minutes and seconds" body computes resetsAt from now', () => {
+  const now = new Date('2026-07-15T12:00:00.000Z');
+  const body = [
+    '> [!WARNING]',
+    '> ## Rate limit exceeded',
+    '>',
+    '> @rutger has exceeded the limit for the number of commits or files that can be',
+    '> reviewed per hour. Please wait **14 minutes and 45 seconds** before requesting',
+    '> another review.',
+  ].join('\n');
+  const result = prStatus.parseRateLimit(body, now);
+  assert.strictEqual(result.rateLimited, true);
+  // 14*60 + 45 = 885 seconds after noon
+  assert.strictEqual(result.resetsAt, '2026-07-15T12:14:45.000Z');
+});
+
+test('relative "minutes" only body computes resetsAt from now', () => {
+  const now = new Date('2026-07-15T12:00:00.000Z');
+  const body = 'Rate limit exceeded. Please wait **22 minutes** before requesting another review.';
+  const result = prStatus.parseRateLimit(body, now);
+  assert.strictEqual(result.rateLimited, true);
+  assert.strictEqual(result.resetsAt, '2026-07-15T12:22:00.000Z');
+});
+
+test('absolute ISO timestamp in body is used directly', () => {
+  const body = 'Rate limit exceeded. Try again after 2026-07-15T13:30:00Z.';
+  const result = prStatus.parseRateLimit(body, new Date('2026-07-15T12:00:00Z'));
+  assert.strictEqual(result.rateLimited, true);
+  assert.strictEqual(result.resetsAt, '2026-07-15T13:30:00.000Z');
+});
+
+test('rate-limit body with no parseable reset returns rateLimited true, null reset', () => {
+  const body = 'Rate limit exceeded — please try again later.';
+  const result = prStatus.parseRateLimit(body, new Date('2026-07-15T12:00:00Z'));
+  assert.strictEqual(result.rateLimited, true);
+  assert.strictEqual(result.resetsAt, null);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// countUnresolvedThreads
+// ═══════════════════════════════════════════════════════════════════
+
+section('countUnresolvedThreads: GraphQL reviewThreads filtered to CodeRabbit + unresolved');
+
+test('countUnresolvedThreads is exported', () => {
+  assert.strictEqual(typeof prStatus.countUnresolvedThreads, 'function');
+});
+
+function thread(login, isResolved) {
+  return {
+    isResolved,
+    comments: { nodes: [{ author: { login } }] },
+  };
+}
+
+test('counts only CodeRabbit unresolved threads', () => {
+  const payload = {
+    nodes: [
+      thread('coderabbitai', false),   // count
+      thread('coderabbitai[bot]', false), // count
+      thread('coderabbitai', true),    // resolved — skip
+      thread('rutger', false),         // not CR — skip
+      thread('CodeRabbit', false),     // case-insensitive — count
+    ],
+  };
+  assert.strictEqual(prStatus.countUnresolvedThreads(payload), 3);
+});
+
+test('accepts a bare nodes array as well as the reviewThreads object', () => {
+  const nodes = [thread('coderabbitai', false), thread('coderabbitai', true)];
+  assert.strictEqual(prStatus.countUnresolvedThreads(nodes), 1);
+  assert.strictEqual(prStatus.countUnresolvedThreads({ nodes }), 1);
+});
+
+test('empty / missing payload returns 0', () => {
+  assert.strictEqual(prStatus.countUnresolvedThreads({ nodes: [] }), 0);
+  assert.strictEqual(prStatus.countUnresolvedThreads(null), 0);
+  assert.strictEqual(prStatus.countUnresolvedThreads(undefined), 0);
+});
+
+test('thread with no comments is ignored', () => {
+  const payload = { nodes: [{ isResolved: false, comments: { nodes: [] } }] };
+  assert.strictEqual(prStatus.countUnresolvedThreads(payload), 0);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// buildSnapshot
+// ═══════════════════════════════════════════════════════════════════
+
+section('buildSnapshot: schema-stable assembly from raw inputs');
+
+test('buildSnapshot is exported', () => {
+  assert.strictEqual(typeof prStatus.buildSnapshot, 'function');
+});
+
+const rawInputs = {
+  pr: 42,
+  ci: { state: 'FAILURE', checks: [{ name: 'test', state: 'FAILURE' }, { name: 'build', state: 'SUCCESS' }] },
+  coderabbitCheckState: 'SUCCESS',
+  reviewThreads: {
+    nodes: [
+      thread('coderabbitai', false),
+      thread('coderabbitai', false),
+      thread('coderabbitai', true),
+      thread('rutger', false),
+    ],
+  },
+  rateLimitCommentBody: 'Rate limit exceeded. Please wait **10 minutes** before requesting another review.',
+  reviewers: [{ login: 'rutger', state: 'APPROVED' }],
+  lastActivityAt: '2026-07-15T11:30:00.000Z',
+  now: new Date('2026-07-15T12:00:00.000Z'),
+};
+
+test('snapshot has schema-stable top-level shape', () => {
+  const snap = prStatus.buildSnapshot(rawInputs);
+  assert.deepStrictEqual(Object.keys(snap).sort(), ['ci', 'coderabbit', 'idle', 'pr', 'reviewers'].sort());
+});
+
+test('snapshot pr and ci pass through', () => {
+  const snap = prStatus.buildSnapshot(rawInputs);
+  assert.strictEqual(snap.pr, 42);
+  assert.strictEqual(snap.ci.state, 'FAILURE');
+  assert.strictEqual(snap.ci.checks.length, 2);
+});
+
+test('coderabbit block wires checkState, unresolvedThreads (from GraphQL), rateLimit', () => {
+  const snap = prStatus.buildSnapshot(rawInputs);
+  assert.strictEqual(snap.coderabbit.checkState, 'SUCCESS');
+  assert.strictEqual(snap.coderabbit.unresolvedThreads, 2);
+  assert.strictEqual(snap.coderabbit.rateLimit.rateLimited, true);
+  assert.strictEqual(snap.coderabbit.rateLimit.resetsAt, '2026-07-15T12:10:00.000Z');
+});
+
+test('idle block computes idleMinutes from lastActivityAt and now', () => {
+  const snap = prStatus.buildSnapshot(rawInputs);
+  assert.strictEqual(snap.idle.lastActivityAt, '2026-07-15T11:30:00.000Z');
+  assert.strictEqual(snap.idle.idleMinutes, 30);
+});
+
+test('reviewers pass through', () => {
+  const snap = prStatus.buildSnapshot(rawInputs);
+  assert.deepStrictEqual(snap.reviewers, [{ login: 'rutger', state: 'APPROVED' }]);
+});
+
+test('missing rate-limit comment body yields not-rate-limited', () => {
+  const snap = prStatus.buildSnapshot({ ...rawInputs, rateLimitCommentBody: null });
+  assert.deepStrictEqual(snap.coderabbit.rateLimit, { rateLimited: false, resetsAt: null });
+});
+
+test('missing lastActivityAt yields null idleMinutes', () => {
+  const snap = prStatus.buildSnapshot({ ...rawInputs, lastActivityAt: null });
+  assert.strictEqual(snap.idle.lastActivityAt, null);
+  assert.strictEqual(snap.idle.idleMinutes, null);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Summary
+// ═══════════════════════════════════════════════════════════════════
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/skills/finalize-coderabbit.test.js
+++ b/tests/skills/finalize-coderabbit.test.js
@@ -74,5 +74,13 @@ test('each poll block self-derives PR_NUMBER (separate shell invocations)', () =
   );
 });
 
+test('both probes are non-fatal so the status-unavailable guard is reachable under set -e/pipefail', () => {
+  const guarded = md.match(/SNAP=\$\(\$PR_STATUS "\$PR_NUMBER" 2>\/dev\/null \|\| true\)/g) || [];
+  assert.ok(
+    guarded.length >= 2,
+    `a failing pr-status probe must not abort the step (needs "2>/dev/null || true"); found ${guarded.length} guarded probes`
+  );
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/skills/finalize-coderabbit.test.js
+++ b/tests/skills/finalize-coderabbit.test.js
@@ -66,5 +66,13 @@ test('no REST-only coderabbit comment-count is the sole advance signal', () => {
   );
 });
 
+test('each poll block self-derives PR_NUMBER (separate shell invocations)', () => {
+  const defs = md.match(/PR_NUMBER=\$\(jq -r \.prNumber \.envoy\/finalize\/state\.json\)/g) || [];
+  assert.ok(
+    defs.length >= 2,
+    `both the initial poll and the re-poll block must derive PR_NUMBER in their own shell; found ${defs.length}`
+  );
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/skills/finalize-coderabbit.test.js
+++ b/tests/skills/finalize-coderabbit.test.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Finalize CodeRabbit step — contract tests.
+ *
+ * Guards the #25 fix: finalize's CodeRabbit poll/advance gates must route through
+ * lib/pr-status.js (GraphQL unresolved-thread count + rate-limit), NOT a REST-only
+ * comment count that misses inline review threads.
+ *
+ * Run: node tests/skills/finalize-coderabbit.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const STEP = path.join(REPO_ROOT, 'skills', 'finalize', 'steps', 'coderabbit.md');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+const md = fs.readFileSync(STEP, 'utf8');
+
+section('finalize CodeRabbit step routes through pr-status.js (#25)');
+
+test('references lib/pr-status.js as the status source', () => {
+  assert.ok(
+    /pr-status\.js/.test(md),
+    'coderabbit.md must invoke lib/pr-status.js for the CodeRabbit signal'
+  );
+});
+
+test('gates on GraphQL-derived unresolvedThreads', () => {
+  assert.ok(
+    /unresolvedThreads/.test(md),
+    'the advance/poll gate must use the unresolvedThreads snapshot field'
+  );
+});
+
+test('honors CodeRabbit rate-limit state from the snapshot', () => {
+  assert.ok(
+    /rateLimit/.test(md),
+    'polling must consult the rateLimit snapshot so a rate-limited review is not read as "clean"'
+  );
+});
+
+test('no REST-only coderabbit comment-count is the sole advance signal', () => {
+  assert.ok(
+    !/select\(\s*\.user\.login\s*==\s*"coderabbitai"\s*\)\]\s*\|\s*length/.test(md),
+    'the REST comment-count poll expression must be removed as the advance signal'
+  );
+});
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/skills/finalize-coderabbit.test.js
+++ b/tests/skills/finalize-coderabbit.test.js
@@ -82,5 +82,13 @@ test('both probes are non-fatal so the status-unavailable guard is reachable und
   );
 });
 
+test('both blocks check for an empty snapshot before running jq (guard, not jq tolerance)', () => {
+  const guards = md.match(/if \[ -z "\$SNAP" \]/g) || [];
+  assert.ok(
+    guards.length >= 2,
+    `both poll blocks must gate jq behind an explicit -z "$SNAP" check so a failed probe can't be misread; found ${guards.length}`
+  );
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Adds `lib/pr-status.js` — a single zero-dependency Node CLI that returns one schema-stable JSON snapshot of a PR's status (CI, CodeRabbit, reviewers, idle) — and rewires the finalize CodeRabbit poll onto it, **closing #25**. Finalize previously gated on a REST comment count, which misses CodeRabbit inline review threads; the advance/complete decision now uses GraphQL `reviewThreads` (unresolved count) plus rate-limit state.

## Changes

- **`lib/pr-status.js`** — pure, unit-tested parse/count functions with the `gh`/GraphQL fetch isolated in thin wrappers:
  - `parseRateLimit(body, now)` → `{ rateLimited, resetsAt }` (absolute ISO or relative "N minutes [and M seconds]")
  - `countUnresolvedThreads(payload)` → unresolved **CodeRabbit** threads from GraphQL `reviewThreads` (isResolved=false + CR author)
  - `summarizeChecks(rollup)` → CI rollup state + CodeRabbit check state
  - `buildSnapshot(raw)` → `{ pr, ci, coderabbit{checkState,unresolvedThreads,rateLimit}, reviewers, idle }`
  - CLI: `node lib/pr-status.js <pr>` prints the snapshot
- **`skills/finalize/steps/coderabbit.md`** — both the initial poll (Step 3) and re-poll completion signal (Step 7) route through `pr-status.js`; the REST comment-count advance signal is removed; rate-limit and terminal-check states are honored.
- **Tests** — `tests/lib/pr-status.test.js` (25 fixture cases, no network) and `tests/skills/finalize-coderabbit.test.js` (5 contract assertions guarding the routing).

## Design note

This drops the REST comment-count check entirely rather than pairing it with the GraphQL check as #25's illustrative diff suggested — #25's own root-cause concludes the REST signal is *unreliable*, not merely insufficient, so a single GraphQL-based source is the better fix.

## Follow-ups (out of scope for #25, filed separately)

- `skills/verification/SKILL.md` still carries the same REST-only comment-count race — `pr-status.js` should become the one CR-completion source everywhere.
- `fetchReviewThreads` uses `reviewThreads(first:100)` with no pagination (pre-existing convention; the new authoritative engine is the place to fix it once).
- Standardize on GraphQL `-F` typed variables (verification/SKILL.md string-interpolates `$OWNER`/`$REPO`).

## Test Plan

- [x] `node tests/lib/pr-status.test.js` — 25 passed
- [x] `node tests/skills/finalize-coderabbit.test.js` — 5 passed
- [x] Full suite — 11 suites, 0 failing
- [x] `node --check` + `bash -n` on all new JS and touched bash blocks

## Linked Issue

Closes #36

---

*Created with Envoy*
