### PR TITLE
fix(finalize): PR-state write passes env before node, not after (fixes #43)

### DIFF
--- a/skills/finalize/SKILL.md
+++ b/skills/finalize/SKILL.md
@@ -148,7 +148,7 @@ PREOF
 # fix-ci and cleanup read this file — do NOT write /tmp/envoy-active-pr.txt; that path is retired.
 PR_NUMBER=$(gh pr view --json number -q .number)
 PR_URL=$(gh pr view --json url -q .url)
-node -e "
+PR_NUMBER="$PR_NUMBER" PR_URL="$PR_URL" node -e "
   const fs = require('fs');
   const p = '.envoy/finalize/state.json';
   const state = JSON.parse(fs.readFileSync(p, 'utf8'));
@@ -156,7 +156,7 @@ node -e "
   state.prUrl = process.env.PR_URL;
   state.updatedAt = new Date().toISOString();
   fs.writeFileSync(p, JSON.stringify(state, null, 2));
-" PR_NUMBER="$PR_NUMBER" PR_URL="$PR_URL"
+"
 ```
 
 ---

--- a/tests/skills/finalize-pr-state.test.js
+++ b/tests/skills/finalize-pr-state.test.js
@@ -38,15 +38,20 @@ const md = fs.readFileSync(SKILL, 'utf8');
 
 section('finalize Step 2: PR-state write passes env correctly');
 
+// Tolerate whitespace and either PR_NUMBER/PR_URL ordering — the contract is
+// "env assignments are a prefix before node", not an exact byte sequence.
+const envAssign = 'PR_(?:NUMBER|URL)="\\$PR_(?:NUMBER|URL)"';
+
 test('uses an env prefix before node (process.env resolves)', () => {
+  const prefixForm = new RegExp(`(?:${envAssign}\\s+){2}node\\s+-e`);
   assert.ok(
-    md.includes('PR_NUMBER="$PR_NUMBER" PR_URL="$PR_URL" node -e'),
+    prefixForm.test(md),
     'the PR-state write must set PR_NUMBER/PR_URL as an env prefix before `node -e`'
   );
 });
 
 test('does NOT place env assignments after node (which become argv → NaN)', () => {
-  const buggySuffix = /node -e "[\s\S]*?"\s*PR_NUMBER="\$PR_NUMBER"\s+PR_URL="\$PR_URL"/;
+  const buggySuffix = new RegExp(`node\\s+-e\\s+"[\\s\\S]*?"\\s*${envAssign}`);
   assert.ok(
     !buggySuffix.test(md),
     'env assignments after `node -e` are read as argv, not env — process.env.PR_NUMBER would be undefined → NaN'

--- a/tests/skills/finalize-pr-state.test.js
+++ b/tests/skills/finalize-pr-state.test.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Finalize Step 2 PR-state write — contract test.
+ *
+ * Guards against the NaN bug: the env assignments for the PR-state write must be
+ * an env PREFIX before `node` (so process.env resolves), not a suffix after it
+ * (which node reads as argv, leaving process.env.PR_NUMBER undefined → NaN).
+ *
+ * Run: node tests/skills/finalize-pr-state.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const SKILL = path.join(REPO_ROOT, 'skills', 'finalize', 'SKILL.md');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+const md = fs.readFileSync(SKILL, 'utf8');
+
+section('finalize Step 2: PR-state write passes env correctly');
+
+test('uses an env prefix before node (process.env resolves)', () => {
+  assert.ok(
+    md.includes('PR_NUMBER="$PR_NUMBER" PR_URL="$PR_URL" node -e'),
+    'the PR-state write must set PR_NUMBER/PR_URL as an env prefix before `node -e`'
+  );
+});
+
+test('does NOT place env assignments after node (which become argv → NaN)', () => {
+  const buggySuffix = /node -e "[\s\S]*?"\s*PR_NUMBER="\$PR_NUMBER"\s+PR_URL="\$PR_URL"/;
+  assert.ok(
+    !buggySuffix.test(md),
+    'env assignments after `node -e` are read as argv, not env — process.env.PR_NUMBER would be undefined → NaN'
+  );
+});
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Fixes a latent bug in `skills/finalize/SKILL.md` Step 2 found while dogfooding finalize on PR #42.

The PR-state write placed the env assignments **after** `node`:

```bash
node -e "…state.prNumber = Number(process.env.PR_NUMBER)…" PR_NUMBER="$PR_NUMBER" PR_URL="$PR_URL"
```

`VAR=val` after a command is passed to `node` as `process.argv`, not exported into `process.env`, so `process.env.PR_NUMBER` was `undefined` → `state.prNumber` was written as **`NaN`** and `prUrl` as `undefined`. `envoy:fix-ci` and `envoy:cleanup` read `prNumber` from `.envoy/finalize/state.json`, so both break on a real run.

## Fix

Move the env assignments to a **prefix before** `node`:

```bash
PR_NUMBER="$PR_NUMBER" PR_URL="$PR_URL" node -e "…"
```

## Test Plan

- [x] `tests/skills/finalize-pr-state.test.js` — contract test asserting the env-prefix form and the absence of the buggy suffix form (RED before the fix, GREEN after)
- [x] Functional smoke: the corrected form writes `prNumber: 42` (integer), not `NaN`
- [x] Full suite green

## Linked Issue

Closes #43

---

*Created with Envoy*
