### PR TITLE
Unify verification onto pr-status.js + paginate reviewThreads (closes #44)

### DIFF
--- a/docs/wiki/Advanced-Patterns.md
+++ b/docs/wiki/Advanced-Patterns.md
@@ -182,3 +182,16 @@ Both are loaded by `pickup` and `review` to avoid repeating the same mistakes.
 - Suggestion from ` ```suggestion ``` ` blocks
 
 Only send to Haiku (cheap LLM) when regex confidence < 0.95. Massive token savings.
+
+## PR Status Snapshot (single source)
+
+**Lib:** `lib/pr-status.js`
+
+`node lib/pr-status.js <pr>` returns one schema-stable JSON snapshot of a PR's health, and is the **single source** for every conversation-completion decision:
+
+- `ci` — check rollup state
+- `coderabbit` — check state, **unresolved CodeRabbit threads** (GraphQL `reviewThreads`, filtered to CodeRabbit + `isResolved=false`), and rate-limit state (`resetsAt`)
+- `threads.unresolved` — all-author unresolved review threads
+- `reviewers`, `idle`
+
+Review-thread fetching paginates (`pageInfo.hasNextPage`), so counts are correct past 100 threads. Both `finalize` (steps/coderabbit.md) and `verification` gate on this snapshot instead of REST comment counts — REST misses inline review threads and is fooled by rate-limiting, which is the CodeRabbit-poll race the single source fixes.

--- a/docs/wiki/Workflow.md
+++ b/docs/wiki/Workflow.md
@@ -58,15 +58,15 @@ Fixes all findings before proceeding.
 Assumes `/envoy:review` has already run. No local reviews here.
 
 1. Push branch and create PR
-2. Poll for GitHub CodeRabbit comments (exponential backoff, 22min max)
+2. Poll GitHub CodeRabbit via the shared `lib/pr-status.js` snapshot — unresolved review threads (GraphQL, not REST comment counts) plus rate-limit state (exponential backoff, 22min max)
 3. Address ALL findings including nitpicks
 4. Reply to each comment with fix + commit hash, resolve thread
 5. Push fixes, re-poll (max 3 cycles)
 6. Poll CI, auto-fix failures via `/envoy:fix-ci`
-7. Final verification: tests, build, lint, zero unresolved conversations
+7. Final verification: tests, build, lint, zero unresolved conversations (read from the same `lib/pr-status.js` snapshot)
 8. Wiki sync
 
-Uses the **completion signal protocol** — "no new comments" must be confirmed 3 consecutive times before the loop stops.
+Uses the **completion signal protocol** — a settled review (not rate-limited AND zero unresolved CodeRabbit threads) must be confirmed 3 consecutive times before the loop stops.
 
 ## 5. Cleanup
 

--- a/lib/pr-status.js
+++ b/lib/pr-status.js
@@ -337,7 +337,6 @@ module.exports = {
   idleMinutesSince,
   buildSnapshot,
   summarizeChecks,
-  fetchReviewThreadsPage,
   fetchReviewThreads,
   getSnapshot,
 };

--- a/lib/pr-status.js
+++ b/lib/pr-status.js
@@ -77,6 +77,24 @@ function countUnresolvedThreads(payload) {
 }
 
 /**
+ * Count unresolved review threads from all authors in a GraphQL reviewThreads payload.
+ *
+ * A thread counts when it is not resolved (`isResolved === false`), regardless of
+ * author. Mirrors `countUnresolvedThreads` in accepting either the reviewThreads
+ * object or a bare nodes array.
+ *
+ * @param {{nodes: object[]}|object[]} payload - reviewThreads object or its nodes array
+ * @returns {number} Count of unresolved threads across all authors
+ */
+function countUnresolvedTotal(payload) {
+  if (!payload) return 0;
+  const nodes = Array.isArray(payload) ? payload : payload.nodes;
+  if (!Array.isArray(nodes)) return 0;
+
+  return nodes.filter((threadNode) => threadNode && threadNode.isResolved === false).length;
+}
+
+/**
  * Whole minutes elapsed between `lastActivityAt` and `now`.
  *
  * @param {string|null} lastActivityAt - ISO timestamp of last PR activity
@@ -102,7 +120,7 @@ function idleMinutesSince(lastActivityAt, now) {
  * @param {object[]} raw.reviewers - Reviewer review states
  * @param {string|null} raw.lastActivityAt - ISO timestamp of last activity
  * @param {Date} [raw.now] - Reference time (defaults to current time)
- * @returns {object} Snapshot with { pr, ci, coderabbit, reviewers, idle }
+ * @returns {object} Snapshot with { pr, ci, coderabbit, threads, reviewers, idle }
  */
 function buildSnapshot(raw) {
   const now = raw.now || new Date();
@@ -116,6 +134,9 @@ function buildSnapshot(raw) {
       checkState: raw.coderabbitCheckState || null,
       unresolvedThreads: countUnresolvedThreads(raw.reviewThreads),
       rateLimit: parseRateLimit(raw.rateLimitCommentBody, now),
+    },
+    threads: {
+      unresolved: countUnresolvedTotal(raw.reviewThreads),
     },
     reviewers: raw.reviewers || [],
     idle: {
@@ -190,32 +211,59 @@ function fetchPrView(prNumber) {
 }
 
 /**
- * Fetch reviewThreads via GraphQL — the authoritative source for unresolved
- * CodeRabbit inline threads (REST misses them, #25).
+ * Fetch a single page of reviewThreads via GraphQL — the authoritative source
+ * for unresolved review threads (REST misses inline CodeRabbit threads, #25).
  * @param {{owner: string, repo: string}} repo
  * @param {number} prNumber
- * @returns {{nodes: object[]}}
+ * @param {string|null} after - endCursor of the previous page, or null for the first page
+ * @returns {{nodes: object[], pageInfo: {hasNextPage: boolean, endCursor: string|null}}}
  */
-function fetchReviewThreads(repo, prNumber) {
+function fetchReviewThreadsPage(repo, prNumber, after) {
   const query = [
-    'query($owner:String!,$repo:String!,$pr:Int!){',
+    'query($owner:String!,$repo:String!,$pr:Int!,$after:String){',
     '  repository(owner:$owner,name:$repo){',
     '    pullRequest(number:$pr){',
-    '      reviewThreads(first:100){',
+    '      reviewThreads(first:100,after:$after){',
+    '        pageInfo{ hasNextPage endCursor }',
     '        nodes{ isResolved comments(first:1){ nodes{ author{ login } } } }',
     '      }',
     '    }',
     '  }',
     '}',
   ].join('\n');
-  const data = ghJson([
+  const args = [
     'api', 'graphql',
     '-f', `query=${query}`,
     '-F', `owner=${repo.owner}`,
     '-F', `repo=${repo.repo}`,
     '-F', `pr=${prNumber}`,
-  ]);
+  ];
+  if (after) args.push('-F', `after=${after}`);
+  const data = ghJson(args);
   return data.data.repository.pullRequest.reviewThreads;
+}
+
+/**
+ * Fetch all reviewThreads for a PR, paginating past the 100-thread page limit
+ * by looping on `pageInfo.hasNextPage` and accumulating nodes across pages.
+ * The page-fetcher is injectable so pagination can be unit-tested without network.
+ * @param {{owner: string, repo: string}} repo
+ * @param {number} prNumber
+ * @param {(repo: object, prNumber: number, after: string|null) => object} [fetchPage]
+ * @returns {{nodes: object[]}}
+ */
+function fetchReviewThreads(repo, prNumber, fetchPage = fetchReviewThreadsPage) {
+  const nodes = [];
+  let after = null;
+  let hasNextPage = true;
+  while (hasNextPage) {
+    const page = fetchPage(repo, prNumber, after);
+    if (page && Array.isArray(page.nodes)) nodes.push(...page.nodes);
+    const pageInfo = (page && page.pageInfo) || {};
+    hasNextPage = Boolean(pageInfo.hasNextPage);
+    after = pageInfo.endCursor || null;
+  }
+  return { nodes };
 }
 
 /**
@@ -285,8 +333,11 @@ if (require.main === module) {
 module.exports = {
   parseRateLimit,
   countUnresolvedThreads,
+  countUnresolvedTotal,
   idleMinutesSince,
   buildSnapshot,
   summarizeChecks,
+  fetchReviewThreadsPage,
+  fetchReviewThreads,
   getSnapshot,
 };

--- a/lib/pr-status.js
+++ b/lib/pr-status.js
@@ -261,7 +261,13 @@ function fetchReviewThreads(repo, prNumber, fetchPage = fetchReviewThreadsPage) 
     if (page && Array.isArray(page.nodes)) nodes.push(...page.nodes);
     const pageInfo = (page && page.pageInfo) || {};
     hasNextPage = Boolean(pageInfo.hasNextPage);
-    after = pageInfo.endCursor || null;
+    const nextAfter = pageInfo.endCursor || null;
+    // Abort rather than hang: if there's another page but the cursor didn't
+    // advance, following it would loop forever on the same page.
+    if (hasNextPage && (nextAfter === null || nextAfter === after)) {
+      throw new Error('reviewThreads pagination did not advance (hasNextPage=true but endCursor missing/unchanged)');
+    }
+    after = nextAfter;
   }
   return { nodes };
 }

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -273,7 +273,7 @@ $ curl -sf http://localhost:5173
 
 ## PR Status
 Unresolved conversations: 0
-New CodeRabbit comments since last push: 0
+Unresolved CodeRabbit threads: 0
 
 ## Conclusion
 All verifications passed. Ready for human review.

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -151,7 +151,7 @@ else
 fi
 ```
 
-### New CodeRabbit Comments Check
+### Unresolved CodeRabbit Threads Check
 
 After pushing fixes, verify no unresolved CodeRabbit threads remain. Read the
 CodeRabbit-only count from the same snapshot — `.coderabbit.unresolvedThreads`:

--- a/skills/verification/SKILL.md
+++ b/skills/verification/SKILL.md
@@ -130,38 +130,46 @@ pgrep -f "vite" > /dev/null && echo "✓ Frontend running" || echo "✗ Frontend
 
 ### PR Conversation Check
 
-If a PR exists, verify zero unresolved conversations:
+If a PR exists, verify zero unresolved conversations. Read the count from the
+single status source (`lib/pr-status.js`) — its `.threads.unresolved` field
+counts unresolved review threads from every author via GraphQL (REST comment
+counts miss inline threads):
 
 ```bash
-OWNER=$(gh repo view --json owner -q '.owner.login')
-REPO=$(gh repo view --json name -q '.name')
 PR_NUMBER=<number>
+PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
 
-# Count unresolved review threads
-UNRESOLVED=$(gh api graphql -f query='
-  query {
-    repository(owner: "'$OWNER'", name: "'$REPO'") {
-      pullRequest(number: '$PR_NUMBER') {
-        reviewThreads(first: 100) {
-          nodes { isResolved }
-        }
-      }
-    }
-  }
-' --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length')
+# Probe is non-fatal: a pr-status failure must not abort under set -e/pipefail.
+SNAP=$($PR_STATUS "$PR_NUMBER" 2>/dev/null || true)
 
-echo "Unresolved PR conversations: $UNRESOLVED"
+# Check for an empty snapshot before jq so jq never runs on empty input.
+if [ -z "$SNAP" ]; then
+  echo "PR status unavailable — could not read unresolved conversation count."
+else
+  UNRESOLVED=$(echo "$SNAP" | jq -r '.threads.unresolved // empty')
+  echo "Unresolved PR conversations: $UNRESOLVED"
+fi
 ```
 
 ### New CodeRabbit Comments Check
 
-After pushing fixes, verify no new CodeRabbit comments appeared:
+After pushing fixes, verify no unresolved CodeRabbit threads remain. Read the
+CodeRabbit-only count from the same snapshot — `.coderabbit.unresolvedThreads`:
 
 ```bash
-# Get comments since last push
-LAST_PUSH=$(git log -1 --format=%cI)
-gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-  --jq "[.[] | select(.user.login == \"coderabbitai\") | select(.created_at > \"$LAST_PUSH\")] | length"
+PR_NUMBER=<number>
+PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
+
+# Probe is non-fatal: a pr-status failure must not abort under set -e/pipefail.
+SNAP=$($PR_STATUS "$PR_NUMBER" 2>/dev/null || true)
+
+# Check for an empty snapshot before jq so jq never runs on empty input.
+if [ -z "$SNAP" ]; then
+  echo "PR status unavailable — could not read CodeRabbit thread count."
+else
+  CR_UNRESOLVED=$(echo "$SNAP" | jq -r '.coderabbit.unresolvedThreads // empty')
+  echo "Unresolved CodeRabbit threads: $CR_UNRESOLVED"
+fi
 ```
 
 ## Fix-and-Verify Cycle (Max 3, with Completion Signal)

--- a/tests/lib/pr-status.test.js
+++ b/tests/lib/pr-status.test.js
@@ -152,7 +152,12 @@ const rawInputs = {
 
 test('snapshot has schema-stable top-level shape', () => {
   const snap = prStatus.buildSnapshot(rawInputs);
-  assert.deepStrictEqual(Object.keys(snap).sort(), ['ci', 'coderabbit', 'idle', 'pr', 'reviewers'].sort());
+  assert.deepStrictEqual(Object.keys(snap).sort(), ['ci', 'coderabbit', 'idle', 'pr', 'reviewers', 'threads'].sort());
+});
+
+test('threads block counts all-author unresolved threads from GraphQL', () => {
+  const snap = prStatus.buildSnapshot(rawInputs);
+  assert.strictEqual(snap.threads.unresolved, 3);
 });
 
 test('snapshot pr and ci pass through', () => {
@@ -257,6 +262,75 @@ test('CodeRabbit check state is picked out by name (case-insensitive)', () => {
 test('no CodeRabbit check yields null coderabbitCheckState', () => {
   const result = prStatus.summarizeChecks([{ name: 'CI', conclusion: 'SUCCESS' }]);
   assert.strictEqual(result.coderabbitCheckState, null);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// countUnresolvedTotal
+// ═══════════════════════════════════════════════════════════════════
+
+section('countUnresolvedTotal: all-author unresolved review threads');
+
+test('counts every unresolved thread regardless of author', () => {
+  const payload = {
+    nodes: [
+      thread('coderabbitai', false),   // count
+      thread('rutger', false),         // count
+      thread('someReviewer', false),   // count
+      thread('coderabbitai', true),    // resolved — skip
+      thread('rutger', true),          // resolved — skip
+    ],
+  };
+  assert.strictEqual(prStatus.countUnresolvedTotal(payload), 3);
+});
+
+test('accepts a bare nodes array as well as the reviewThreads object', () => {
+  const nodes = [thread('rutger', false), thread('coderabbitai', false), thread('rutger', true)];
+  assert.strictEqual(prStatus.countUnresolvedTotal(nodes), 2);
+  assert.strictEqual(prStatus.countUnresolvedTotal({ nodes }), 2);
+});
+
+test('empty / missing payload returns 0', () => {
+  assert.strictEqual(prStatus.countUnresolvedTotal({ nodes: [] }), 0);
+  assert.strictEqual(prStatus.countUnresolvedTotal(null), 0);
+  assert.strictEqual(prStatus.countUnresolvedTotal(undefined), 0);
+});
+
+test('threads without an explicit false isResolved are not counted', () => {
+  const payload = { nodes: [{ isResolved: true }, { isResolved: undefined }, {}] };
+  assert.strictEqual(prStatus.countUnresolvedTotal(payload), 0);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// fetchReviewThreads pagination (injected page-fetcher — no network)
+// ═══════════════════════════════════════════════════════════════════
+
+section('fetchReviewThreads: accumulates nodes across paginated fetchPage calls');
+
+test('accumulates all nodes across multiple pages', () => {
+  const pages = [
+    { nodes: [thread('rutger', false), thread('coderabbitai', false)], pageInfo: { hasNextPage: true, endCursor: 'c1' } },
+    { nodes: [thread('someReviewer', true)], pageInfo: { hasNextPage: true, endCursor: 'c2' } },
+    { nodes: [thread('rutger', true)], pageInfo: { hasNextPage: false, endCursor: 'c3' } },
+  ];
+  const seenCursors = [];
+  const fakeFetchPage = (repo, prNumber, after) => {
+    seenCursors.push(after);
+    return pages.shift();
+  };
+  const result = prStatus.fetchReviewThreads({ owner: 'o', repo: 'r' }, 7, fakeFetchPage);
+  assert.strictEqual(result.nodes.length, 4);
+  assert.deepStrictEqual(seenCursors, [null, 'c1', 'c2']);
+});
+
+test('single page (hasNextPage false) returns that page only', () => {
+  let calls = 0;
+  const fakeFetchPage = () => {
+    calls++;
+    return { nodes: [thread('rutger', false)], pageInfo: { hasNextPage: false, endCursor: 'c1' } };
+  };
+  const result = prStatus.fetchReviewThreads({ owner: 'o', repo: 'r' }, 7, fakeFetchPage);
+  assert.strictEqual(result.nodes.length, 1);
+  assert.strictEqual(calls, 1);
 });
 
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/lib/pr-status.test.js
+++ b/tests/lib/pr-status.test.js
@@ -333,6 +333,20 @@ test('single page (hasNextPage false) returns that page only', () => {
   assert.strictEqual(calls, 1);
 });
 
+test('aborts (does not hang) when hasNextPage stays true but the cursor never advances', () => {
+  // Safety cap so a missing guard surfaces as a distinct error, not an infinite hang.
+  let calls = 0;
+  const fakeFetchPage = () => {
+    if (++calls > 50) throw new Error('SAFETY: loop did not terminate');
+    return { nodes: [thread('rutger', false)], pageInfo: { hasNextPage: true, endCursor: null } };
+  };
+  assert.throws(
+    () => prStatus.fetchReviewThreads({ owner: 'o', repo: 'r' }, 7, fakeFetchPage),
+    /did not advance/,
+    'must abort with a clear invariant error, not hang, when the cursor does not advance'
+  );
+});
+
 // ═══════════════════════════════════════════════════════════════════
 // Summary
 // ═══════════════════════════════════════════════════════════════════

--- a/tests/skills/verification-prstatus.test.js
+++ b/tests/skills/verification-prstatus.test.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Verification skill conversation checks — contract tests.
+ *
+ * Guards #44 task-2: the verification skill's two conversation checks must read
+ * from lib/pr-status.js (single source), NOT inline GraphQL reviewThreads /
+ * REST coderabbit comment counts.
+ *
+ * - PR Conversation Check reads .threads.unresolved (all-author)
+ * - New CodeRabbit Comments Check reads .coderabbit.unresolvedThreads
+ *
+ * Run: node tests/skills/verification-prstatus.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const SKILL = path.join(REPO_ROOT, 'skills', 'verification', 'SKILL.md');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+const md = fs.readFileSync(SKILL, 'utf8');
+
+section('verification conversation checks route through pr-status.js (#44)');
+
+test('references lib/pr-status.js as the status source', () => {
+  assert.ok(
+    /pr-status\.js/.test(md),
+    'SKILL.md conversation checks must invoke lib/pr-status.js'
+  );
+});
+
+test('all-author check reads .threads.unresolved', () => {
+  assert.ok(
+    /\.threads\.unresolved/.test(md),
+    'PR Conversation Check must read the all-author .threads.unresolved snapshot field'
+  );
+});
+
+test('CodeRabbit check reads .coderabbit.unresolvedThreads', () => {
+  assert.ok(
+    /\.coderabbit\.unresolvedThreads/.test(md),
+    'New CodeRabbit Comments Check must read the .coderabbit.unresolvedThreads snapshot field'
+  );
+});
+
+test('no inline GraphQL reviewThreads query remains', () => {
+  assert.ok(
+    !/reviewThreads\(first:\s*100\)/.test(md),
+    'the inline GraphQL reviewThreads(first: 100) query must be removed'
+  );
+});
+
+test('no $OWNER/$REPO string-interpolated repository() query remains', () => {
+  assert.ok(
+    !/repository\(owner:\s*"'\$OWNER'"/.test(md),
+    'the $OWNER/$REPO-interpolated GraphQL query must be removed'
+  );
+});
+
+test('no REST coderabbit comment-count expression remains', () => {
+  assert.ok(
+    !/select\(\.user\.login\s*==\s*\\?"coderabbitai\\?"\)[\s\S]*?\|\s*length/.test(md),
+    'the REST coderabbitai comment-count (select ... | length) must be removed'
+  );
+});
+
+test('probe is non-fatal (2>/dev/null || true)', () => {
+  assert.ok(
+    /\$PR_STATUS "\$PR_NUMBER" 2>\/dev\/null \|\| true/.test(md),
+    'the pr-status probe must be non-fatal so it does not abort under set -e/pipefail'
+  );
+});
+
+test('empty-snapshot guard before jq (-z "$SNAP")', () => {
+  assert.ok(
+    /if \[ -z "\$SNAP" \]/.test(md),
+    'jq must be gated behind an explicit -z "$SNAP" guard'
+  );
+});
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/skills/verification-prstatus.test.js
+++ b/tests/skills/verification-prstatus.test.js
@@ -97,5 +97,12 @@ test('empty-snapshot guard before jq (-z "$SNAP")', () => {
   );
 });
 
+test('no stale "new comments since last push" evidence phrasing remains', () => {
+  assert.ok(
+    !/new CodeRabbit comments since last push/i.test(md),
+    'the check now measures unresolved threads, not new comments since last push — stale phrasing must be gone'
+  );
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Makes `lib/pr-status.js` the single source everywhere PR-conversation/CodeRabbit completion is judged. `skills/verification/SKILL.md` previously ran the pre-#25 REST comment-count race plus an inline GraphQL thread check that lacked pagination and string-interpolated `$OWNER`/`$REPO`. Both now route through the engine, and the engine's `reviewThreads` fetch is now paginated. **Closes #44.**

## Changes

- **`lib/pr-status.js`**
  - `fetchReviewThreads` **paginates** (`pageInfo.hasNextPage`/`endCursor`, `$after` cursor) so counts are correct past 100 threads — via an injectable `fetchPage` seam so pagination is unit-testable without network.
  - New pure **`countUnresolvedTotal(payload)`** (all-author) alongside the existing CR-only `countUnresolvedThreads`.
  - New top-level **`threads: { unresolved }`** snapshot block. `coderabbit.unresolvedThreads` is unchanged (finalize depends on it).
- **`skills/verification/SKILL.md`** — both conversation checks now read from `pr-status.js`: the all-author "PR Conversation Check" reads `.threads.unresolved`, the "Unresolved CodeRabbit Threads Check" reads `.coderabbit.unresolvedThreads`. Inline GraphQL, REST comment-count, and `$OWNER`/`$REPO` interpolation removed; non-fatal probe pattern mirroring finalize.
- **Tests** — pagination/all-author fixtures in `tests/lib/pr-status.test.js`; new `tests/skills/verification-prstatus.test.js` contract test guarding the routing.

## Review

Ran `/envoy:review` (Medium tier): lint ✓, cleanup removed a dead export, AI review caught + fixed a stale evidence-example line (now guarded by a test). Full suite green; TDD RED→GREEN on every commit.

## Still out of scope (follow-up needed)

The same conversation-check pattern still lives in `skills/coderabbit-pr-review/SKILL.md` and `skills/finalize/steps/verify.md` (inline unpaginated `reviewThreads` / REST CR count / `$OWNER`-`$REPO` interp). These were explicitly out of #44's scope and need their own tracking issue so they don't get lost when #44 closes.

## Test Plan

- [x] `node tests/lib/pr-status.test.js` — 32 passed
- [x] `node tests/skills/verification-prstatus.test.js` — 9 passed
- [x] Full suite — 13 files, 0 failing
- [x] `node --check` + `bash -n` on new JS and touched bash blocks

## Linked Issue

Closes #44

---

*Created with Envoy*
