### PR TITLE
docs(wiki): register Phase 5 shepherding skills (babysit/prs/hotfix)

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -6,7 +6,7 @@ Professional development workflows for Claude Code and GitHub Copilot.
 
 - [[Getting Started]] — Installation and setup
 - [[Workflow]] — The full brainstorm-to-merge pipeline
-- [[Skills Reference]] — All 23 skills with descriptions
+- [[Skills Reference]] — All 26 skills with descriptions
 - [[Hooks]] — Automation hooks and profiles
 - [[Stack Profiles]] — Technology-specific best practices
 - [[Token Optimization]] — How Envoy minimizes token usage

--- a/docs/wiki/Skills-Reference.md
+++ b/docs/wiki/Skills-Reference.md
@@ -1,6 +1,6 @@
 # Skills Reference
 
-Envoy includes 23 skills organized by purpose.
+Envoy includes 26 skills organized by purpose.
 
 ## Core Workflow
 
@@ -11,6 +11,14 @@ Envoy includes 23 skills organized by purpose.
 | `envoy:review` | After implementation, before creating PR |
 | `envoy:finalize` | Implementation reviewed, ready to create PR |
 | `envoy:cleanup` | After PR merged, before starting new work |
+
+## Lifecycle & PR Shepherding
+
+| Skill | Trigger |
+|-------|---------|
+| `envoy:babysit` | Move open PRs forward in one pass — re-trigger a rate-limited CodeRabbit, fix CI, resolve threads (composes with `/loop`) |
+| `envoy:prs` | Read-only status across open PRs — CI, CodeRabbit, unresolved threads, idle |
+| `envoy:hotfix` | Urgent single-defect fix on a fast path — worktree + failing test + verification, no brainstorm |
 
 ## Quality & Review
 


### PR DESCRIPTION
Adds the three Phase 5 skills shipped in #50 to the wiki Skills Reference (new 'Lifecycle & PR Shepherding' section) and bumps the skill count 23 → 26 in Skills-Reference.md and Home.md.

Docs-only. After merge, `docs/wiki/` syncs to the GitHub wiki via /envoy:wiki-sync from main.