### PR TITLE
Route coderabbit-pr-review + finalize/verify gates through pr-status.js (closes #49)

### DIFF
--- a/.envoy-tasks/49.json
+++ b/.envoy-tasks/49.json
@@ -1,0 +1,40 @@
+{
+  "$schemaVersion": "1",
+  "strategy": "sequential",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Route coderabbit-pr-review/SKILL.md through pr-status.js",
+      "description": "Replace the inline reviewThreads/REST CodeRabbit comment-count in coderabbit-pr-review with node lib/pr-status.js reads; CR gate reads .coderabbit.unresolvedThreads; drop $OWNER/$REPO interpolation; non-fatal probe with -z guard, mirroring finalize/steps/coderabbit.md.",
+      "files": [
+        "skills/coderabbit-pr-review/SKILL.md",
+        "tests/skills/coderabbit-pr-review-prstatus.test.js"
+      ],
+      "acceptance": [
+        "No inline reviewThreads(first:...) GraphQL, no REST coderabbitai ... | length count, and no $OWNER/$REPO-interpolated query remain in the file",
+        "The CodeRabbit gate reads .coderabbit.unresolvedThreads from node lib/pr-status.js",
+        "Probe is non-fatal (2>/dev/null || true) with a -z \"$SNAP\" guard before jq",
+        "New contract test tests/skills/coderabbit-pr-review-prstatus.test.js guards the routing; full suite green"
+      ]
+    },
+    {
+      "id": "task-2",
+      "title": "Route finalize/steps/verify.md through pr-status.js",
+      "description": "Migrate finalize/steps/verify.md's conversation checks onto node lib/pr-status.js: all-author gate reads .threads.unresolved, CodeRabbit gate reads .coderabbit.unresolvedThreads; remove inline GraphQL/REST and $OWNER/$REPO interpolation; non-fatal probe.",
+      "files": [
+        "skills/finalize/steps/verify.md",
+        "tests/skills/finalize-verify-prstatus.test.js"
+      ],
+      "acceptance": [
+        "No inline reviewThreads(first:...) GraphQL, no REST coderabbitai comment-count, and no $OWNER/$REPO-interpolated query remain",
+        "All-author gate reads .threads.unresolved; CodeRabbit gate reads .coderabbit.unresolvedThreads",
+        "Probe is non-fatal (2>/dev/null || true) with a -z \"$SNAP\" guard before jq",
+        "New contract test tests/skills/finalize-verify-prstatus.test.js guards the routing; full suite green"
+      ],
+      "dependsOn": [
+        "task-1"
+      ]
+    }
+  ],
+  "issueNumber": 49
+}

--- a/.envoy-tasks/49.json
+++ b/.envoy-tasks/49.json
@@ -1,40 +1,33 @@
 {
   "$schemaVersion": "1",
+  "issueNumber": 49,
   "strategy": "sequential",
   "tasks": [
     {
       "id": "task-1",
-      "title": "Route coderabbit-pr-review/SKILL.md through pr-status.js",
-      "description": "Replace the inline reviewThreads/REST CodeRabbit comment-count in coderabbit-pr-review with node lib/pr-status.js reads; CR gate reads .coderabbit.unresolvedThreads; drop $OWNER/$REPO interpolation; non-fatal probe with -z guard, mirroring finalize/steps/coderabbit.md.",
-      "files": [
-        "skills/coderabbit-pr-review/SKILL.md",
-        "tests/skills/coderabbit-pr-review-prstatus.test.js"
-      ],
+      "title": "Route coderabbit-pr-review/SKILL.md unresolved-count gate through pr-status.js",
+      "description": "Migrate ONLY the Step 8 unresolved-thread count gate onto node lib/pr-status.js (.threads.unresolved). The Step 5 comment-body fetch and Step 6 thread-ID GraphQL stay (pr-status exposes counts, not bodies/IDs); switch the Step 6 query's $OWNER/$REPO interpolation to -F typed variables.",
+      "files": ["skills/coderabbit-pr-review/SKILL.md", "tests/skills/coderabbit-pr-review-prstatus.test.js"],
       "acceptance": [
-        "No inline reviewThreads(first:...) GraphQL, no REST coderabbitai ... | length count, and no $OWNER/$REPO-interpolated query remain in the file",
-        "The CodeRabbit gate reads .coderabbit.unresolvedThreads from node lib/pr-status.js",
-        "Probe is non-fatal (2>/dev/null || true) with a -z \"$SNAP\" guard before jq",
+        "The Step 8 unresolved-count gate reads .threads.unresolved from node lib/pr-status.js; no REST/inline 'reviewThreads ... | length' count-gate remains",
+        "The Step 5 comment-body fetch and the Step 6 thread-ID GraphQL are preserved (they provide data pr-status.js does not expose)",
+        "The Step 6 thread-ID query uses -F typed variables instead of $OWNER/$REPO string interpolation",
+        "The migrated gate uses the non-fatal probe (2>/dev/null || true) with a -z \"$SNAP\" guard before jq",
         "New contract test tests/skills/coderabbit-pr-review-prstatus.test.js guards the routing; full suite green"
       ]
     },
     {
       "id": "task-2",
       "title": "Route finalize/steps/verify.md through pr-status.js",
-      "description": "Migrate finalize/steps/verify.md's conversation checks onto node lib/pr-status.js: all-author gate reads .threads.unresolved, CodeRabbit gate reads .coderabbit.unresolvedThreads; remove inline GraphQL/REST and $OWNER/$REPO interpolation; non-fatal probe.",
-      "files": [
-        "skills/finalize/steps/verify.md",
-        "tests/skills/finalize-verify-prstatus.test.js"
-      ],
+      "description": "Migrate finalize/steps/verify.md's conversation checks onto node lib/pr-status.js: all-author gate reads .threads.unresolved, CodeRabbit gate reads .coderabbit.unresolvedThreads; remove inline GraphQL/REST and $OWNER/$REPO interpolation; non-fatal probe. Re-verify during pickup that verify.md's usage is count-only (like verification/SKILL.md) before deleting any query.",
+      "files": ["skills/finalize/steps/verify.md", "tests/skills/finalize-verify-prstatus.test.js"],
       "acceptance": [
-        "No inline reviewThreads(first:...) GraphQL, no REST coderabbitai comment-count, and no $OWNER/$REPO-interpolated query remain",
-        "All-author gate reads .threads.unresolved; CodeRabbit gate reads .coderabbit.unresolvedThreads",
+        "Count/conversation gates route through node lib/pr-status.js (.threads.unresolved all-author, .coderabbit.unresolvedThreads for CR); no count-gate REST/inline query remains",
+        "Any query fetching data pr-status.js does not expose (bodies/IDs) is preserved; $OWNER/$REPO interpolation removed from what stays",
         "Probe is non-fatal (2>/dev/null || true) with a -z \"$SNAP\" guard before jq",
         "New contract test tests/skills/finalize-verify-prstatus.test.js guards the routing; full suite green"
       ],
-      "dependsOn": [
-        "task-1"
-      ]
+      "dependsOn": ["task-1"]
     }
-  ],
-  "issueNumber": 49
+  ]
 }

--- a/skills/coderabbit-pr-review/SKILL.md
+++ b/skills/coderabbit-pr-review/SKILL.md
@@ -160,23 +160,27 @@ gh api graphql -f query='
 **Note:** You need the thread's node ID, which may require fetching via GraphQL:
 
 ```bash
-gh api graphql -f query='
-  query {
-    repository(owner: "'$OWNER'", name: "'$REPO'") {
-      pullRequest(number: <pr-number>) {
-        reviewThreads(first: 100) {
-          nodes {
-            id
-            isResolved
-            comments(first: 1) {
-              nodes { body }
+gh api graphql \
+  -f query='
+    query($owner:String!, $repo:String!, $pr:Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              isResolved
+              comments(first: 1) {
+                nodes { body }
+              }
             }
           }
         }
       }
     }
-  }
-'
+  ' \
+  -F owner="$OWNER" \
+  -F repo="$REPO" \
+  -F pr=<pr-number>
 ```
 
 ### Step 7: Push Fixes
@@ -187,21 +191,24 @@ git push
 
 ### Step 8: Verify Resolution
 
-```bash
-# Check for any remaining unresolved threads
-UNRESOLVED=$(gh api graphql -f query='
-  query {
-    repository(owner: "'$OWNER'", name: "'$REPO'") {
-      pullRequest(number: <pr-number>) {
-        reviewThreads(first: 100) {
-          nodes { isResolved }
-        }
-      }
-    }
-  }
-' --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length')
+Read the remaining unresolved-thread count from the single status source
+(`lib/pr-status.js`) — its `.threads.unresolved` field counts unresolved review
+threads from every author via GraphQL:
 
-echo "Unresolved threads: $UNRESOLVED"
+```bash
+PR_NUMBER=<pr-number>
+PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
+
+# Probe is non-fatal: a pr-status failure must not abort under set -e/pipefail.
+SNAP=$($PR_STATUS "$PR_NUMBER" 2>/dev/null || true)
+
+# Check for an empty snapshot before jq so jq never runs on empty input.
+if [ -z "$SNAP" ]; then
+  echo "PR status unavailable — could not read unresolved thread count."
+else
+  UNRESOLVED=$(echo "$SNAP" | jq -r '.threads.unresolved // empty')
+  echo "Unresolved threads: $UNRESOLVED"
+fi
 ```
 
 ### Step 9: Report

--- a/skills/finalize/steps/verify.md
+++ b/skills/finalize/steps/verify.md
@@ -32,7 +32,8 @@ SNAP=$($PR_STATUS "$PR_NUMBER" 2>/dev/null || true)
 if [ -z "$SNAP" ]; then
   echo "PR status unavailable — cannot confirm zero unresolved conversations."
 else
-  echo "$SNAP" | jq -r '.threads.unresolved'
+  UNRESOLVED=$(echo "$SNAP" | jq -r '.threads.unresolved // empty')
+  echo "Unresolved conversations: ${UNRESOLVED:-unknown}"
 fi
 ```
 

--- a/skills/finalize/steps/verify.md
+++ b/skills/finalize/steps/verify.md
@@ -22,18 +22,18 @@ npm run lint
 gh pr checks $PR_NUMBER --json name,state,conclusion \
   --jq '.[] | select(.state != "PENDING" and .state != "QUEUED") | select(.conclusion != "SUCCESS") | .name + ": " + .conclusion'
 
-# Zero unresolved PR conversations
-gh api graphql -f query='
-  query {
-    repository(owner: "'$OWNER'", name: "'$REPO'") {
-      pullRequest(number: '$PR_NUMBER') {
-        reviewThreads(first: 100) {
-          nodes { isResolved }
-        }
-      }
-    }
-  }
-' --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length'
+# Zero unresolved PR conversations — one snapshot source (all-author unresolved
+# review threads) shared with CodeRabbit polling.
+PR_STATUS="node ${CLAUDE_SKILL_DIR}/../../lib/pr-status.js"
+# Probe is non-fatal: a pr-status failure must not abort the step under set -e/pipefail.
+SNAP=$($PR_STATUS "$PR_NUMBER" 2>/dev/null || true)
+# A missing snapshot (status probe failed) is NOT proof of zero unresolved
+# conversations. Check before jq so jq never runs on empty input.
+if [ -z "$SNAP" ]; then
+  echo "PR status unavailable — cannot confirm zero unresolved conversations."
+else
+  echo "$SNAP" | jq -r '.threads.unresolved'
+fi
 ```
 
 **All checks must pass with evidence.**

--- a/tests/skills/coderabbit-pr-review-prstatus.test.js
+++ b/tests/skills/coderabbit-pr-review-prstatus.test.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * coderabbit-pr-review skill Step 8 count-gate — contract tests.
+ *
+ * Guards #49 task-1: the skill's Step 8 verify-resolution count gate must read
+ * from lib/pr-status.js (single source), NOT an inline GraphQL reviewThreads
+ * count. Step 5 comment-body fetch and Step 6 thread-ID GraphQL are PRESERVED;
+ * Step 6 must use -F typed GraphQL variables (no $OWNER/$REPO interpolation).
+ *
+ * Run: node tests/skills/coderabbit-pr-review-prstatus.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const SKILL = path.join(REPO_ROOT, 'skills', 'coderabbit-pr-review', 'SKILL.md');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+const md = fs.readFileSync(SKILL, 'utf8');
+
+section('coderabbit-pr-review Step 8 routes through pr-status.js (#49)');
+
+test('Step 8 reads .threads.unresolved via lib/pr-status.js', () => {
+  assert.ok(
+    /pr-status\.js/.test(md),
+    'Step 8 must invoke lib/pr-status.js as the status source'
+  );
+  assert.ok(
+    /\.threads\.unresolved/.test(md),
+    'Step 8 must read the all-author .threads.unresolved snapshot field'
+  );
+});
+
+test('no coderabbit REST select ... | length count-gate remains', () => {
+  assert.ok(
+    !/select\([^)]*coderabbitai[\s\S]*?\|\s*length/.test(md),
+    'the REST coderabbitai select(...) | length count expression must be gone'
+  );
+});
+
+test('no reviewThreads isResolved==false ... | length count-gate remains', () => {
+  assert.ok(
+    !/reviewThreads[\s\S]*?isResolved\s*==\s*false[\s\S]*?\|\s*length/.test(md),
+    'the inline reviewThreads count-gate (map(select(.isResolved==false)) | length) must be gone from Step 8'
+  );
+});
+
+test('probe is non-fatal (2>/dev/null || true)', () => {
+  assert.ok(
+    /\$PR_STATUS "\$PR_NUMBER" 2>\/dev\/null \|\| true/.test(md),
+    'the pr-status probe must be non-fatal so it does not abort under set -e/pipefail'
+  );
+});
+
+test('empty-snapshot guard before jq (-z "$SNAP")', () => {
+  assert.ok(
+    /if \[ -z "\$SNAP" \]/.test(md),
+    'jq must be gated behind an explicit -z "$SNAP" guard'
+  );
+});
+
+section('coderabbit-pr-review preserves Step 5 + Step 6 fetches (#49)');
+
+test('Step 5 comment-body fetch line still present', () => {
+  assert.ok(
+    /pulls\/<pr-number>\/comments\b/.test(md) &&
+      /\{id,\s*path,\s*line,\s*body/.test(md),
+    'the REST comment-body fetch (pulls/<pr-number>/comments → {id, path, line, body,...}) must be preserved'
+  );
+});
+
+test('Step 6 thread-ID GraphQL query still present', () => {
+  assert.ok(
+    /reviewThreads\(first:\s*100\)/.test(md),
+    'the Step 6 reviewThreads(first: 100) thread-ID query must be preserved'
+  );
+});
+
+test('no $OWNER/$REPO-interpolated repository() query remains anywhere', () => {
+  assert.ok(
+    !/owner:\s*"'\$OWNER'"/.test(md),
+    'GraphQL queries must use -F typed vars, not $OWNER string interpolation'
+  );
+});
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/skills/coderabbit-pr-review-prstatus.test.js
+++ b/tests/skills/coderabbit-pr-review-prstatus.test.js
@@ -50,13 +50,6 @@ test('Step 8 reads .threads.unresolved via lib/pr-status.js', () => {
   );
 });
 
-test('no coderabbit REST select ... | length count-gate remains', () => {
-  assert.ok(
-    !/select\([^)]*coderabbitai[\s\S]*?\|\s*length/.test(md),
-    'the REST coderabbitai select(...) | length count expression must be gone'
-  );
-});
-
 test('no reviewThreads isResolved==false ... | length count-gate remains', () => {
   assert.ok(
     !/reviewThreads[\s\S]*?isResolved\s*==\s*false[\s\S]*?\|\s*length/.test(md),

--- a/tests/skills/finalize-verify-prstatus.test.js
+++ b/tests/skills/finalize-verify-prstatus.test.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Finalize verify.md conversation gate — contract tests.
+ *
+ * Guards #49 task-2: the finalize verification step's single conversation gate
+ * (Step 9) must read from lib/pr-status.js (single source), NOT the inline
+ * GraphQL reviewThreads count with $OWNER/$REPO-interpolated repository().
+ *
+ * - Conversation gate reads .threads.unresolved (all-author) via pr-status.js
+ * - Probe is non-fatal + guarded by -z "$SNAP" before jq
+ *
+ * Run: node tests/skills/finalize-verify-prstatus.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const STEP = path.join(REPO_ROOT, 'skills', 'finalize', 'steps', 'verify.md');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+const md = fs.readFileSync(STEP, 'utf8');
+
+section('finalize verify conversation gate routes through pr-status.js (#49)');
+
+test('references lib/pr-status.js as the status source', () => {
+  assert.ok(
+    /pr-status\.js/.test(md),
+    'verify.md conversation gate must invoke lib/pr-status.js'
+  );
+});
+
+test('all-author gate reads .threads.unresolved', () => {
+  assert.ok(
+    /\.threads\.unresolved/.test(md),
+    'the conversation gate must read the all-author .threads.unresolved snapshot field'
+  );
+});
+
+test('no inline GraphQL reviewThreads query remains', () => {
+  assert.ok(
+    !/reviewThreads\(first:\s*\d+\)/.test(md),
+    'the inline GraphQL reviewThreads(first: N) query must be removed'
+  );
+});
+
+test('no $OWNER/$REPO string-interpolated repository() query remains', () => {
+  assert.ok(
+    !/repository\(owner:\s*"'\$OWNER'"/.test(md),
+    'the $OWNER/$REPO-interpolated GraphQL query must be removed'
+  );
+});
+
+test('probe is non-fatal (2>/dev/null || true)', () => {
+  assert.ok(
+    /\$PR_STATUS "\$PR_NUMBER" 2>\/dev\/null \|\| true/.test(md),
+    'the pr-status probe must be non-fatal so it does not abort under set -e/pipefail'
+  );
+});
+
+test('empty-snapshot guard before jq (-z "$SNAP")', () => {
+  assert.ok(
+    /if \[ -z "\$SNAP" \]/.test(md),
+    'jq must be gated behind an explicit -z "$SNAP" guard'
+  );
+});
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/skills/finalize-verify-prstatus.test.js
+++ b/tests/skills/finalize-verify-prstatus.test.js
@@ -83,5 +83,12 @@ test('empty-snapshot guard before jq (-z "$SNAP")', () => {
   );
 });
 
+test('reads the field with a // empty fallback (matches sibling idiom)', () => {
+  assert.ok(
+    /\.threads\.unresolved \/\/ empty/.test(md),
+    'the gate must use the // empty jq fallback like the other pr-status gates, not a bare read that prints null'
+  );
+});
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Completes the `lib/pr-status.js` single-source migration started in #44 by routing the two remaining sibling gates onto the engine. **Closes #49.** After this, all four conversation-completion gates (finalize/coderabbit, verification, coderabbit-pr-review, finalize/verify) read from one snapshot.

## Changes

- **`skills/coderabbit-pr-review/SKILL.md`** — **only** the Step 8 unresolved-thread *count* gate migrated to `node lib/pr-status.js` (`.threads.unresolved`, all-author). The Step 5 comment-body fetch and Step 6 thread-ID GraphQL are **preserved** — `pr-status.js` exposes counts, not bodies or thread IDs, so those genuinely can't route through it. The Step 6 thread-ID query switched from `$OWNER`/`$REPO` string interpolation to `-F` typed variables.
- **`skills/finalize/steps/verify.md`** — its single all-author conversation gate migrated to `.threads.unresolved` (count-only, clean), matching the sibling `// empty` idiom.
- **Tests** — two new contract tests with positive (preservation) + negative (no-regression) guards.

## Scope note

Task-1's original acceptance (as I'd filed #49) over-reached — it would have deleted GraphQL that fetches bodies/IDs and broken the skill. Caught at the pickup viability check; scope narrowed to the count gate only, with both spec + quality reviewers verifying nothing beyond it was touched.

## Review

`/envoy:review` (Medium tier): lint ✓, cleanup clean, AI review caught + fixed a vacuous test assertion and a `// empty` idiom divergence in verify.md. Full suite (20 suites) green; TDD RED→GREEN on every commit.

## Test Plan

- [x] `node tests/skills/coderabbit-pr-review-prstatus.test.js` — 7 passed
- [x] `node tests/skills/finalize-verify-prstatus.test.js` — 7 passed
- [x] Full suite — 20 suites, 0 failing
- [x] `node --check` + `bash -n` on new JS and touched blocks

## Linked Issue

Closes #49

---

*Created with Envoy*
