### PR TITLE
chore(release): bump to v3.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "Claude Code marketplace entry for the Envoy professional development workflow plugin.",
-    "version": "2.4.1"
+    "version": "3.0.0"
   },
   "plugins": [
     {
       "name": "envoy",
-      "version": "2.4.1",
+      "version": "3.0.0",
       "description": "Expose the full Envoy professional development workflow plugin through a single marketplace entry.",
       "author": {
         "name": "Rutger Dijkstra",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "envoy",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "Plugin-safe Claude Code distribution of Envoy professional development workflows with 26 skills, 25 stack profiles, and self-learning hooks.",
   "author": {
     "name": "Rutger Dijkstra",


### PR DESCRIPTION
Bumps all manifests to `3.0.0` in lockstep (verified with `sync-versions --check`). Tag `v3.0.0` at merge per the release process.

Marks the 3.0 line: pr-status single-source across all four gates (#25→#36→#44→#49), Phase 5 lifecycle shepherding shipped (#50), and the first CI live (#55). Note: tracker #26's Phase 3 enforcement rearchitecture (the 3.0 centerpiece) is still ahead — flagging in case you'd prefer a `3.0.0-alpha` until it lands.

---

*Created with Envoy*