### PR TITLE
Fix #1560 worktree ordering race — migrate .envoy/ into the worktree + guard (Phase 2 Spike B, closes #56)

### DIFF
--- a/.envoy-tasks/56.json
+++ b/.envoy-tasks/56.json
@@ -1,0 +1,55 @@
+{
+  "$schemaVersion": "1",
+  "strategy": "sequential",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "worktree-state helpers (migrate + guard)",
+      "intent": "Provide the migrate + guard primitives so the #1560 race fix is testable and reusable, not inline bash.",
+      "behavior": [
+        "Given a main checkout with .envoy/ and an empty worktree dir, when migrateEnvoyState(main, wt) runs, then .envoy/ exists under wt and is gone from main",
+        "Given a main checkout with no .envoy/, when migrateEnvoyState runs, then it is a no-op and does not throw",
+        "Given process.cwd() is not the expected worktree, when assertInWorktree(wt) runs, then it exits non-zero with a clear message; given cwd IS the worktree, it returns without aborting"
+      ],
+      "files": [
+        "lib/worktree-state.js",
+        "tests/lib/worktree-state.test.js"
+      ],
+      "acceptance": [
+        "migrateEnvoyState(mainDir, worktreeDir) moves .envoy/ main->worktree, removes it from main, and no-ops when main has none",
+        "assertInWorktree(expectedWorktree) cross-checks git worktree list and aborts (non-zero) on cwd mismatch, passes when cwd matches",
+        "Zero-dependency Node; unit-tested with temp dirs for migrate and an isolated/controlled cwd for the guard"
+      ],
+      "outOfScope": [
+        "Changing how preflight decides the worktree path",
+        "Any non-pickup skill"
+      ]
+    },
+    {
+      "id": "task-2",
+      "title": "wire into pickup + real-worktree integration test",
+      "intent": "Make the actual pickup flow migrate state and guard writes, proven end-to-end against a real git worktree (not a tmpdir unit test).",
+      "behavior": [
+        "Given the pickup worktree step runs after creating a worktree, when it completes, then .envoy/ is present in the worktree and absent from the main checkout",
+        "Given a state write is attempted with cwd != the expected worktree, when the guard runs, then it aborts instead of writing to the wrong place"
+      ],
+      "files": [
+        "skills/pickup/steps/worktree.md",
+        "tests/scripts/worktree-migration.test.js"
+      ],
+      "acceptance": [
+        "steps/worktree.md calls migrateEnvoyState after worktree creation (mirroring the cp -r .claude step) and uses assertInWorktree to guard state writes",
+        "A real git-worktree integration test creates an actual worktree, runs the migrate, and asserts .envoy/ migrated (present in worktree, absent from main) plus the guard aborts on a cwd mismatch",
+        "Full existing suite stays green under scripts/run-tests.js"
+      ],
+      "outOfScope": [
+        "Spike C (Copilot install)",
+        "Refactoring unrelated pickup steps"
+      ],
+      "dependsOn": [
+        "task-1"
+      ]
+    }
+  ],
+  "issueNumber": 56
+}

--- a/lib/worktree-state.js
+++ b/lib/worktree-state.js
@@ -1,0 +1,136 @@
+/**
+ * Worktree State
+ *
+ * Fixes the #1560 worktree-state race: when a feature worktree is created,
+ * Envoy runtime state (.envoy/) must live inside that worktree, not in the
+ * main checkout where a concurrent session could read or clobber it.
+ *
+ * Provides migrateEnvoyState (relocate .envoy/ main -> worktree) and
+ * assertInWorktree (guard that the process is running in the expected,
+ * git-registered worktree). Zero dependencies — node builtins only.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+/**
+ * Move the `.envoy/` directory from `mainDir` into `worktreeDir`.
+ *
+ * - If `mainDir/.envoy` exists, it is relocated so that `worktreeDir/.envoy`
+ *   holds its contents and `mainDir/.envoy` no longer exists.
+ * - Pre-existing-target policy: **replace**. If `worktreeDir/.envoy` already
+ *   exists it is removed first, then the source directory takes its place.
+ *   This is the simplest correct behavior — the worktree's freshly-migrated
+ *   state is authoritative for that worktree; a stale target would otherwise
+ *   reintroduce exactly the cross-checkout leakage this function prevents.
+ * - If `mainDir/.envoy` does not exist, this is a no-op and does not throw.
+ * - Uses `fs.renameSync`; on a cross-device error (EXDEV) it falls back to a
+ *   recursive copy followed by `fs.rmSync` of the source.
+ *
+ * @param {string} mainDir - Path to the main checkout.
+ * @param {string} worktreeDir - Path to the target worktree.
+ * @returns {void}
+ */
+function migrateEnvoyState(mainDir, worktreeDir) {
+  const source = path.join(mainDir, '.envoy');
+  const target = path.join(worktreeDir, '.envoy');
+
+  if (!fs.existsSync(source)) return;
+
+  if (fs.existsSync(target)) {
+    fs.rmSync(target, { recursive: true, force: true });
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+
+  try {
+    fs.renameSync(source, target);
+  } catch (err) {
+    if (err.code !== 'EXDEV') throw err;
+    fs.cpSync(source, target, { recursive: true });
+    fs.rmSync(source, { recursive: true, force: true });
+  }
+}
+
+/**
+ * List absolute paths of all git-registered worktrees.
+ * Parses `git worktree list --porcelain` from the given directory.
+ * @param {string} cwd - Directory to run git from.
+ * @returns {string[]} Worktree root paths (as reported by git).
+ */
+function gitWorktreePaths(cwd) {
+  const out = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return out
+    .split('\n')
+    .filter((line) => line.startsWith('worktree '))
+    .map((line) => line.slice('worktree '.length).trim());
+}
+
+/**
+ * Resolve a path to its absolute, symlink-free real path when it exists,
+ * falling back to a plain absolute resolution when it does not.
+ * @param {string} p
+ * @returns {string}
+ */
+function realAbs(p) {
+  const abs = path.resolve(p);
+  try {
+    return fs.realpathSync(abs);
+  } catch (_err) {
+    return abs;
+  }
+}
+
+/**
+ * Assert that the current process is running inside `expectedWorktree`.
+ *
+ * Contract: returns normally on a match; throws an Error on any mismatch.
+ * Callers that want a hard stop can wrap the call and `process.exit(1)` in the
+ * catch — this function never exits the process itself, which keeps it unit
+ * testable.
+ *
+ * Two conditions must both hold:
+ *   1. `cwd` resolves to the same real path as `expectedWorktree`.
+ *   2. `expectedWorktree` is a git-registered worktree per `listWorktrees()`.
+ *
+ * Paths are compared after resolving to absolute real paths so symlinked
+ * temp/worktree roots compare equal.
+ *
+ * @param {string} expectedWorktree - Path the process is expected to run in.
+ * @param {object} [options]
+ * @param {string} [options.cwd=process.cwd()] - Current directory to check.
+ * @param {() => string[]} [options.listWorktrees] - Returns registered
+ *   worktree paths. Defaults to parsing `git worktree list --porcelain`.
+ *   Injectable so tests need not touch the real repo.
+ * @returns {void}
+ * @throws {Error} When cwd is not the expected worktree, or the expected
+ *   worktree is not registered.
+ */
+function assertInWorktree(expectedWorktree, options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const listWorktrees = options.listWorktrees || (() => gitWorktreePaths(cwd));
+
+  const expected = realAbs(expectedWorktree);
+  const actual = realAbs(cwd);
+
+  if (actual !== expected) {
+    throw new Error(
+      `Not in expected worktree: cwd is ${actual}, expected ${expected}`
+    );
+  }
+
+  const registered = listWorktrees().map(realAbs);
+  if (!registered.includes(expected)) {
+    throw new Error(
+      `${expected} is not a registered git worktree`
+    );
+  }
+}
+
+module.exports = { migrateEnvoyState, assertInWorktree };

--- a/skills/pickup/steps/worktree.md
+++ b/skills/pickup/steps/worktree.md
@@ -50,15 +50,21 @@ cp -r .claude .worktrees/<N>-$TOPIC/
 # Migrate any pre-worktree .envoy/ state into the worktree (fixes #1560 — pickup
 # preflight writes .envoy/ in the main checkout before the worktree exists, so it
 # would otherwise be stranded where a concurrent session could read or clobber it).
-node -e "require('${CLAUDE_SKILL_DIR}/../../lib/worktree-state').migrateEnvoyState(process.cwd(), '.worktrees/<N>-'+process.env.TOPIC)"
+# Pass the worktree path via shell $TOPIC as a node arg — a `node -e` child cannot
+# see the un-exported shell var through its environment, so reading it that way
+# would be undefined and strand state in `.worktrees/<N>-undefined`.
+node -e "require('${CLAUDE_SKILL_DIR}/../../lib/worktree-state').migrateEnvoyState(process.cwd(), process.argv[1])" ".worktrees/<N>-$TOPIC"
+
+# Record this worktree's absolute path so later steps can prove they're inside it.
+node -e "const fs=require('fs'),path=require('path'),wt=path.resolve(process.argv[1]); fs.mkdirSync(wt+'/.envoy',{recursive:true}); fs.writeFileSync(wt+'/.envoy/expected-worktree', wt)" ".worktrees/<N>-$TOPIC"
 ```
 
-After Step 5 `cd`s into the worktree, all subsequent `.envoy/` state writes are
-guarded by `assertInWorktree` (see `lib/worktree-state.js`): it throws if the
-process is not running in this exact, git-registered worktree. That invariant is
-what keeps a concurrent session in the main checkout from racing on Envoy state —
-the migration relocates the state, and the guard enforces that writes only ever
-happen from inside the worktree that owns it.
+Step 5 `cd`s into the worktree and then **invokes** `assertInWorktree` (see
+`lib/worktree-state.js`) against the `.envoy/expected-worktree` marker written
+above: the guard throws if the process isn't running in this exact, git-registered
+worktree. Because the migration removed `.envoy/` from the main checkout, a state
+write attempted from the main checkout finds no marker and aborts — that's what
+keeps a concurrent main-checkout session from racing on Envoy state.
 
 ### Step 5: Merge Permissions (REQUIRED)
 
@@ -102,6 +108,10 @@ Read `.worktrees/$TOPIC/.claude/settings.local.json` and ensure these permission
 
 ```bash
 cd .worktrees/<N>-$TOPIC
+
+# Guard: abort before any .envoy/ write if we're not actually inside this worktree
+# (fixes #1560 — a write from the main checkout would strand or clobber state).
+node -e "const ws=require('${CLAUDE_SKILL_DIR}/../../lib/worktree-state'),fs=require('fs'); ws.assertInWorktree(fs.readFileSync('.envoy/expected-worktree','utf8').trim())"
 ```
 
 ### Step 6: Detect Stack Profiles

--- a/skills/pickup/steps/worktree.md
+++ b/skills/pickup/steps/worktree.md
@@ -46,7 +46,19 @@ git worktree add .worktrees/<N>-$TOPIC feature/<N>-$TOPIC
 
 # Copy Claude settings to worktree
 cp -r .claude .worktrees/<N>-$TOPIC/
+
+# Migrate any pre-worktree .envoy/ state into the worktree (fixes #1560 — pickup
+# preflight writes .envoy/ in the main checkout before the worktree exists, so it
+# would otherwise be stranded where a concurrent session could read or clobber it).
+node -e "require('${CLAUDE_SKILL_DIR}/../../lib/worktree-state').migrateEnvoyState(process.cwd(), '.worktrees/<N>-'+process.env.TOPIC)"
 ```
+
+After Step 5 `cd`s into the worktree, all subsequent `.envoy/` state writes are
+guarded by `assertInWorktree` (see `lib/worktree-state.js`): it throws if the
+process is not running in this exact, git-registered worktree. That invariant is
+what keeps a concurrent session in the main checkout from racing on Envoy state —
+the migration relocates the state, and the guard enforces that writes only ever
+happen from inside the worktree that owns it.
 
 ### Step 5: Merge Permissions (REQUIRED)
 

--- a/tests/lib/worktree-state.test.js
+++ b/tests/lib/worktree-state.test.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Worktree State — Test Suite
+ *
+ * Run: node tests/lib/worktree-state.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const LIB = path.join(__dirname, '..', '..', 'lib');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Load module
+// ═══════════════════════════════════════════════════════════════════
+
+const worktreeState = require(path.join(LIB, 'worktree-state'));
+
+// ═══════════════════════════════════════════════════════════════════
+// Exports
+// ═══════════════════════════════════════════════════════════════════
+
+section('exports');
+
+test('migrateEnvoyState is exported', () => {
+  assert.strictEqual(typeof worktreeState.migrateEnvoyState, 'function');
+});
+
+test('assertInWorktree is exported', () => {
+  assert.strictEqual(typeof worktreeState.assertInWorktree, 'function');
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// migrateEnvoyState
+// ═══════════════════════════════════════════════════════════════════
+
+section('migrateEnvoyState: move .envoy main → worktree');
+
+test('moves .envoy from main into worktree and removes from main', () => {
+  const root = makeTmp('wt-migrate-');
+  const mainDir = path.join(root, 'main');
+  const worktreeDir = path.join(root, 'wt');
+  fs.mkdirSync(mainDir, { recursive: true });
+  fs.mkdirSync(worktreeDir, { recursive: true });
+  fs.mkdirSync(path.join(mainDir, '.envoy'), { recursive: true });
+  fs.writeFileSync(path.join(mainDir, '.envoy', 'state.json'), '{"a":1}');
+
+  worktreeState.migrateEnvoyState(mainDir, worktreeDir);
+
+  assert.ok(!fs.existsSync(path.join(mainDir, '.envoy')), 'main/.envoy should be gone');
+  assert.ok(fs.existsSync(path.join(worktreeDir, '.envoy')), 'worktree/.envoy should exist');
+  assert.strictEqual(
+    fs.readFileSync(path.join(worktreeDir, '.envoy', 'state.json'), 'utf8'),
+    '{"a":1}',
+    'contents should be preserved'
+  );
+  cleanup(root);
+});
+
+test('no-op when main has no .envoy (does not throw)', () => {
+  const root = makeTmp('wt-migrate-');
+  const mainDir = path.join(root, 'main');
+  const worktreeDir = path.join(root, 'wt');
+  fs.mkdirSync(mainDir, { recursive: true });
+  fs.mkdirSync(worktreeDir, { recursive: true });
+
+  assert.doesNotThrow(() => worktreeState.migrateEnvoyState(mainDir, worktreeDir));
+  assert.ok(!fs.existsSync(path.join(worktreeDir, '.envoy')), 'no .envoy created');
+  cleanup(root);
+});
+
+test('replaces pre-existing worktree/.envoy without crashing', () => {
+  const root = makeTmp('wt-migrate-');
+  const mainDir = path.join(root, 'main');
+  const worktreeDir = path.join(root, 'wt');
+  fs.mkdirSync(path.join(mainDir, '.envoy'), { recursive: true });
+  fs.writeFileSync(path.join(mainDir, '.envoy', 'state.json'), '{"fresh":true}');
+  fs.mkdirSync(path.join(worktreeDir, '.envoy'), { recursive: true });
+  fs.writeFileSync(path.join(worktreeDir, '.envoy', 'stale.json'), '{"stale":true}');
+
+  worktreeState.migrateEnvoyState(mainDir, worktreeDir);
+
+  assert.ok(!fs.existsSync(path.join(mainDir, '.envoy')), 'main/.envoy should be gone');
+  assert.ok(
+    fs.existsSync(path.join(worktreeDir, '.envoy', 'state.json')),
+    'migrated state.json should be present'
+  );
+  assert.ok(
+    !fs.existsSync(path.join(worktreeDir, '.envoy', 'stale.json')),
+    'stale target file should be replaced'
+  );
+  cleanup(root);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// assertInWorktree
+// ═══════════════════════════════════════════════════════════════════
+
+section('assertInWorktree: guard cwd against registered worktree');
+
+test('passes when cwd matches a registered worktree', () => {
+  const root = makeTmp('wt-guard-');
+  const wt = path.join(root, 'wt');
+  fs.mkdirSync(wt, { recursive: true });
+
+  assert.doesNotThrow(() =>
+    worktreeState.assertInWorktree(wt, {
+      cwd: wt,
+      listWorktrees: () => [wt],
+    })
+  );
+  cleanup(root);
+});
+
+test('throws when cwd is not the expected worktree', () => {
+  const root = makeTmp('wt-guard-');
+  const wt = path.join(root, 'wt');
+  const elsewhere = path.join(root, 'elsewhere');
+  fs.mkdirSync(wt, { recursive: true });
+  fs.mkdirSync(elsewhere, { recursive: true });
+
+  assert.throws(
+    () =>
+      worktreeState.assertInWorktree(wt, {
+        cwd: elsewhere,
+        listWorktrees: () => [wt],
+      }),
+    /worktree/i
+  );
+  cleanup(root);
+});
+
+test('throws when expected path is not a registered worktree', () => {
+  const root = makeTmp('wt-guard-');
+  const wt = path.join(root, 'wt');
+  fs.mkdirSync(wt, { recursive: true });
+
+  assert.throws(
+    () =>
+      worktreeState.assertInWorktree(wt, {
+        cwd: wt,
+        listWorktrees: () => [], // not registered
+      }),
+    /worktree/i
+  );
+  cleanup(root);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Summary
+// ═══════════════════════════════════════════════════════════════════
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/worktree-state.test.js
+++ b/tests/lib/worktree-state.test.js
@@ -120,6 +120,35 @@ test('replaces pre-existing worktree/.envoy without crashing', () => {
   cleanup(root);
 });
 
+test('falls back to copy+delete when rename fails cross-device (EXDEV)', () => {
+  const root = makeTmp('wt-migrate-');
+  const mainDir = path.join(root, 'main');
+  const worktreeDir = path.join(root, 'wt');
+  fs.mkdirSync(path.join(mainDir, '.envoy'), { recursive: true });
+  fs.writeFileSync(path.join(mainDir, '.envoy', 'state.json'), '{"x":1}');
+  fs.mkdirSync(worktreeDir, { recursive: true });
+
+  const realRename = fs.renameSync;
+  fs.renameSync = () => {
+    const e = new Error('cross-device link not permitted');
+    e.code = 'EXDEV';
+    throw e;
+  };
+  try {
+    worktreeState.migrateEnvoyState(mainDir, worktreeDir);
+  } finally {
+    fs.renameSync = realRename;
+  }
+
+  assert.ok(!fs.existsSync(path.join(mainDir, '.envoy')), 'main/.envoy removed after EXDEV fallback');
+  assert.strictEqual(
+    fs.readFileSync(path.join(worktreeDir, '.envoy', 'state.json'), 'utf8'),
+    '{"x":1}',
+    'contents copied via the EXDEV fallback'
+  );
+  cleanup(root);
+});
+
 // ═══════════════════════════════════════════════════════════════════
 // assertInWorktree
 // ═══════════════════════════════════════════════════════════════════
@@ -170,6 +199,24 @@ test('throws when expected path is not a registered worktree', () => {
         listWorktrees: () => [], // not registered
       }),
     /worktree/i
+  );
+  cleanup(root);
+});
+
+test('resolves a symlinked cwd against the real registered path (macOS /tmp pitfall)', () => {
+  const root = makeTmp('wt-guard-');
+  const real = path.join(root, 'real-wt');
+  fs.mkdirSync(real, { recursive: true });
+  const link = path.join(root, 'link-wt');
+  fs.symlinkSync(real, link);
+
+  // cwd + expected given via the symlink, registered via the real path — realpath
+  // resolution must make them compare equal so a legit worktree does not false-abort.
+  assert.doesNotThrow(() =>
+    worktreeState.assertInWorktree(link, {
+      cwd: link,
+      listWorktrees: () => [real],
+    })
   );
   cleanup(root);
 });

--- a/tests/scripts/worktree-migration.test.js
+++ b/tests/scripts/worktree-migration.test.js
@@ -136,19 +136,31 @@ test('aborts when cwd is the main checkout (a different registered path)', () =>
 
 section('pickup worktree step wires the migration');
 
-test('worktree.md references migrateEnvoyState', () => {
+test('worktree.md invokes migrateEnvoyState via a node -e call', () => {
   const md = fs.readFileSync(WORKTREE_STEP, 'utf8');
   assert.ok(
-    /migrateEnvoyState/.test(md),
-    'skills/pickup/steps/worktree.md must call migrateEnvoyState so state is relocated into the worktree'
+    /node -e "[^"]*migrateEnvoyState/.test(md),
+    'worktree.md must actually invoke migrateEnvoyState (node -e), not just mention it'
   );
 });
 
-test('worktree.md documents the assertInWorktree guard on state writes', () => {
+test('the migrate call gets the worktree path from the shell $TOPIC, not process.env.TOPIC', () => {
   const md = fs.readFileSync(WORKTREE_STEP, 'utf8');
   assert.ok(
-    /assertInWorktree/.test(md),
-    'worktree.md must reference assertInWorktree so the state-write invariant is documented'
+    !/process\.env\.TOPIC/.test(md),
+    'TOPIC is an un-exported shell var; process.env.TOPIC is undefined in a node -e child and strands state in .worktrees/<N>-undefined'
+  );
+  assert.ok(
+    /migrateEnvoyState[\s\S]*?"\.worktrees\/<N>-\$TOPIC"/.test(md),
+    'the worktree path must be passed via shell expansion ($TOPIC) as a node arg'
+  );
+});
+
+test('worktree.md INVOKES assertInWorktree to guard state writes (not just prose)', () => {
+  const md = fs.readFileSync(WORKTREE_STEP, 'utf8');
+  assert.ok(
+    /node -e "[^"]*assertInWorktree/.test(md),
+    'worktree.md must actually call assertInWorktree in a node -e guard, not only describe it'
   );
 });
 

--- a/tests/scripts/worktree-migration.test.js
+++ b/tests/scripts/worktree-migration.test.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Worktree Migration — Real git-worktree integration test.
+ *
+ * Exercises lib/worktree-state against an actual `git worktree add` (not a
+ * tmpdir-only stub): seeds .envoy/ in the main checkout, migrates it, and
+ * asserts it lands in the worktree and leaves main. Also drives assertInWorktree
+ * with the REAL default `git worktree list` so the guard genuinely proves the
+ * git integration. Finally a contract check that skills/pickup/steps/worktree.md
+ * wires migrateEnvoyState in, so the pickup step can't silently regress.
+ *
+ * Run: node tests/scripts/worktree-migration.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const LIB = path.join(REPO_ROOT, 'lib');
+const WORKTREE_STEP = path.join(REPO_ROOT, 'skills', 'pickup', 'steps', 'worktree.md');
+
+const worktreeState = require(path.join(LIB, 'worktree-state'));
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+/**
+ * Build a throwaway git repo with a real feature worktree.
+ * Returns { root, mainCheckout, worktreeDir }.
+ */
+function makeRepoWithWorktree() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'wt-integ-')));
+  const mainCheckout = path.join(root, 'main');
+  fs.mkdirSync(mainCheckout, { recursive: true });
+
+  git(mainCheckout, 'init', '-q', '-b', 'main');
+  git(mainCheckout, 'config', 'user.email', 'test@example.com');
+  git(mainCheckout, 'config', 'user.name', 'Test');
+  fs.writeFileSync(path.join(mainCheckout, 'README.md'), '# seed\n');
+  git(mainCheckout, 'add', 'README.md');
+  git(mainCheckout, 'commit', '-q', '-m', 'initial');
+
+  git(mainCheckout, 'branch', 'feature/42-topic');
+  const worktreeDir = path.join(mainCheckout, '.worktrees', '42-topic');
+  git(mainCheckout, 'worktree', 'add', '-q', worktreeDir, 'feature/42-topic');
+
+  return { root, mainCheckout, worktreeDir };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Migration against a real worktree
+// ═══════════════════════════════════════════════════════════════════
+
+section('migrateEnvoyState against a real git worktree');
+
+test('.envoy migrates into the worktree and leaves the main checkout', () => {
+  const { root, mainCheckout, worktreeDir } = makeRepoWithWorktree();
+  try {
+    fs.mkdirSync(path.join(mainCheckout, '.envoy'), { recursive: true });
+    fs.writeFileSync(path.join(mainCheckout, '.envoy', 'marker.txt'), 'MIGRATED_MARKER');
+
+    worktreeState.migrateEnvoyState(mainCheckout, worktreeDir);
+
+    assert.ok(
+      !fs.existsSync(path.join(mainCheckout, '.envoy')),
+      'main checkout .envoy should be gone'
+    );
+    const migrated = path.join(worktreeDir, '.envoy', 'marker.txt');
+    assert.ok(fs.existsSync(migrated), 'worktree .envoy/marker.txt should exist');
+    assert.strictEqual(
+      fs.readFileSync(migrated, 'utf8'),
+      'MIGRATED_MARKER',
+      'marker contents preserved through migration'
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Guard against the REAL `git worktree list`
+// ═══════════════════════════════════════════════════════════════════
+
+section('assertInWorktree with the real git-worktree list');
+
+test('passes when cwd is the real registered worktree', () => {
+  const { root, worktreeDir } = makeRepoWithWorktree();
+  try {
+    assert.doesNotThrow(
+      () => worktreeState.assertInWorktree(worktreeDir, { cwd: worktreeDir }),
+      'the registered worktree must pass the guard using real `git worktree list`'
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('aborts when cwd is the main checkout (a different registered path)', () => {
+  const { root, mainCheckout, worktreeDir } = makeRepoWithWorktree();
+  try {
+    assert.throws(
+      () => worktreeState.assertInWorktree(worktreeDir, { cwd: mainCheckout }),
+      /worktree/i,
+      'running from the main checkout must abort the worktree guard'
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Wiring contract — pickup step must invoke the migration
+// ═══════════════════════════════════════════════════════════════════
+
+section('pickup worktree step wires the migration');
+
+test('worktree.md references migrateEnvoyState', () => {
+  const md = fs.readFileSync(WORKTREE_STEP, 'utf8');
+  assert.ok(
+    /migrateEnvoyState/.test(md),
+    'skills/pickup/steps/worktree.md must call migrateEnvoyState so state is relocated into the worktree'
+  );
+});
+
+test('worktree.md documents the assertInWorktree guard on state writes', () => {
+  const md = fs.readFileSync(WORKTREE_STEP, 'utf8');
+  assert.ok(
+    /assertInWorktree/.test(md),
+    'worktree.md must reference assertInWorktree so the state-write invariant is documented'
+  );
+});
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Fixes the #1560 worktree ordering race (Phase 2 Spike B of #26). Pickup's `preflight.js` runs at skill-load in the **main checkout** (before the worktree exists) and writes `.envoy/` state there; `steps/worktree.md` copied `.claude/` but never `.envoy/`, so state was stranded in the main checkout while the worktree had none. **Closes #56.**

## Approach (write-then-migrate)

- **`lib/worktree-state.js`** (new, zero-dep):
  - `migrateEnvoyState(mainDir, worktreeDir)` — moves `.envoy/` from main into the worktree (rename, EXDEV copy+delete fallback), no-ops when main has none, replaces a pre-existing target.
  - `assertInWorktree(expected, {cwd, listWorktrees})` — throws unless `cwd` (realpath) equals the expected worktree AND it's a registered `git worktree`. Injectable for hermetic tests.
- **`skills/pickup/steps/worktree.md`** — Step 4 migrates `.envoy/` into the worktree (path passed via shell `$TOPIC` argv) and writes an `.envoy/expected-worktree` marker; Step 5 invokes `assertInWorktree` after `cd`, so a state write from the main checkout aborts (its marker was migrated away).
- **Real git-worktree integration test** — actual `git init`/`worktree add`, asserts migration (present in worktree, absent from main) + guard passes in-worktree / aborts in-main using the **real** `git worktree list`.

## Review notes

Review caught a **critical** bug pre-merge: the migrate call originally read `process.env.TOPIC` (an un-exported shell var → `undefined`), which would have stranded state in `.worktrees/<N>-undefined` and defeated the fix. Fixed to pass `$TOPIC` via argv, and the guard (previously only documented) is now actually invoked. Contract tests strengthened to forbid `process.env.TOPIC` and require a real `assertInWorktree` invocation.

## Known residual scope (deferred to Phase 3 enforcement, per #26)

- The guard is a single point-in-time check after `cd`, not a per-write gate; continuous enforcement is Phase 3.
- No lock against two truly-concurrent pickups racing on the main-checkout `.envoy/` during the pre-worktree window (matches the issue's out-of-scope note).

## Test Plan

- [x] `node scripts/run-tests.js` — 24 files green (incl. 2 new: `worktree-state.test.js` 10 cases, `worktree-migration.test.js` 6 cases)
- [x] Real git-worktree integration test proves migrate + guard end-to-end
- [x] `bash -n` on the edited pickup step blocks

## Linked Issue

Closes #56

---

*Created with Envoy*
