### PR TITLE
Phase 3 foundational: plugin-level observe-mode gates + active-skill.json lifecycle (closes #60)

### DIFF
--- a/.envoy-tasks/60.json
+++ b/.envoy-tasks/60.json
@@ -1,0 +1,55 @@
+{
+  "$schemaVersion": "1",
+  "strategy": "sequential",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "active-skill.json lifecycle",
+      "intent": "The enforcement gates key off active-skill.json; without a lifecycle a stale marker blocks everything. Give it TTL + session liveness + branch match + explicit clear.",
+      "behavior": [
+        "Given a fresh marker written by writeActiveSkill, when readActiveSkill runs, then it returns the marker object",
+        "Given a marker older than the TTL, or from a different git branch, when readActiveSkill runs, then it returns null (treated as absent)",
+        "Given clearActiveSkill, when it runs, then the marker file is removed and it does not throw if the file is already absent"
+      ],
+      "files": [
+        "lib/active-skill.js",
+        "tests/lib/active-skill.test.js",
+        "skills/cleanup/preflight.js"
+      ],
+      "acceptance": [
+        "lib/active-skill.js exports writeActiveSkill(dir, meta), readActiveSkill(dir) (null when stale by TTL/branch/session-liveness), clearActiveSkill(dir) (no throw if absent)",
+        "The marker carries startedAt + branch + session identifier so staleness can be judged",
+        "cleanup clears the marker via clearActiveSkill",
+        "Zero-dependency Node; unit-tested with temp dirs and injectable clock/branch (hermetic)"
+      ],
+      "outOfScope": [
+        "Migrating every skill preflight write in this task if it balloons scope — at minimum pickup's preflight writes via the helper",
+        "The gates themselves (task-2)"
+      ]
+    },
+    {
+      "id": "task-2",
+      "title": "plugin-level observe-mode gates",
+      "intent": "Make agent-guard/stop-audit actually register (Spike A: per-skill frontmatter never does) and gather false-positive data before ever blocking.",
+      "behavior": [
+        "Given the plugin hooks are installed, when an Agent tool use or a Stop occurs while a rigid skill is active, then agent-guard/stop-audit run at the plugin level, consult readActiveSkill + contract.json, and in observe mode append a would-block record to .envoy/observe-log.jsonl and exit 0",
+        "Given the guard script throws, when the hook runs, then it still exits 0 (fail-open on crash)"
+      ],
+      "files": [
+        "hooks/hooks.json",
+        "lib/contract-guard.js",
+        "tests/hooks/observe-gates.test.js"
+      ],
+      "acceptance": [
+        "hooks/hooks.json registers plugin-level PreToolUse matcher Agent -> agent-guard and Stop -> stop-audit (via the existing hook-runner path)",
+        "Observe mode: would-block events are appended to .envoy/observe-log.jsonl and the gate exits 0 always, including when the guard logic throws (fail-open)",
+        "The dead per-skill hooks: frontmatter blocks are removed from the rigid skills' SKILL.md",
+        "A contract/behaviour test proves registration + observe-logging + fail-open; full suite green under scripts/run-tests.js"
+      ],
+      "dependsOn": [
+        "task-1"
+      ]
+    }
+  ],
+  "issueNumber": 60
+}

--- a/hooks/agent-guard.js
+++ b/hooks/agent-guard.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * ABOUTME: Plugin-level PreToolUse[Agent] observe gate — logs would-block Agent dispatches.
+ * ABOUTME: Never blocks; delegates the decision to the active skill's contract.
+ */
+
+const { observe } = require('./observe-gate');
+
+/**
+ * Entry point invoked by hook-runner with the raw stdin payload.
+ * @param {string} data
+ */
+function run(data) {
+  observe('agent-guard', data);
+}
+
+if (require.main === module) {
+  let input = '';
+  try {
+    input = require('fs').readFileSync(0, 'utf8');
+  } catch {
+    input = '';
+  }
+  run(input);
+  process.exit(0);
+}
+
+module.exports = { run };

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,6 +22,16 @@
             "_profiles": ["minimal", "standard", "strict"]
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.js\" agent-guard",
+            "_profiles": ["minimal", "standard", "strict"]
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -62,6 +72,11 @@
       {
         "matcher": "",
         "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.js\" stop-audit",
+            "_profiles": ["minimal", "standard", "strict"]
+          },
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.js\" stop-batch-lint",

--- a/hooks/observe-gate.js
+++ b/hooks/observe-gate.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * ABOUTME: Plugin-level observe-mode gate core for agent-guard and stop-audit.
+ * ABOUTME: Resolves the active skill's contract, logs would-block decisions, never blocks.
+ *
+ * OBSERVE MODE: these gates only watch. When the active rigid skill's contract
+ * would block an Agent dispatch or a Stop, we append one JSON line to
+ * .envoy/observe-log.jsonl and exit 0 anyway. Enforcement (exit 2) stays out of
+ * this path entirely — we call the non-exiting evaluate* variants, never run*.
+ *
+ * FAIL-OPEN: any error is swallowed. A broken gate must never block a tool call.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..');
+const { readActiveSkill } = require(path.join(PLUGIN_ROOT, 'lib', 'active-skill'));
+const { evaluateAgentGuard, evaluateStopAudit } = require(path.join(PLUGIN_ROOT, 'lib', 'contract-guard'));
+
+/**
+ * Append one observe record to .envoy/observe-log.jsonl under `cwd`.
+ * @param {string} cwd
+ * @param {object} record
+ */
+function appendObserveLog(cwd, record) {
+  const dir = path.join(cwd, '.envoy');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(path.join(dir, 'observe-log.jsonl'), `${JSON.stringify(record)}\n`);
+}
+
+/**
+ * Run one observe gate. Resolves the active skill (null → no-op), evaluates the
+ * contract's would-block decision, and logs it. Always returns without throwing.
+ * @param {'agent-guard'|'stop-audit'} gate
+ * @param {string} data raw stdin payload (the tool-use / stop event JSON)
+ */
+function observe(gate, data) {
+  try {
+    const cwd = process.cwd();
+    const active = readActiveSkill(cwd);
+    if (!active) return; // no rigid skill owns the session — nothing to guard
+
+    const contractPath = path.join(PLUGIN_ROOT, 'skills', active.skill, 'contract.json');
+
+    let decision;
+    if (gate === 'agent-guard') {
+      let event = {};
+      try {
+        event = JSON.parse(data || '{}');
+      } catch {
+        return; // malformed event — fail open, nothing to observe
+      }
+      decision = evaluateAgentGuard(contractPath, event);
+    } else {
+      decision = evaluateStopAudit(contractPath, cwd);
+    }
+
+    if (!decision || !decision.block) return;
+
+    const record = {
+      ts: new Date().toISOString(),
+      skill: active.skill,
+      gate,
+      reason: decision.reason,
+    };
+    if (decision.tool) record.tool = decision.tool;
+    appendObserveLog(cwd, record);
+  } catch {
+    // fail-open: never block a tool call on gate failure
+  }
+}
+
+module.exports = { observe, appendObserveLog };

--- a/hooks/stop-audit.js
+++ b/hooks/stop-audit.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * ABOUTME: Plugin-level Stop observe gate — logs would-block Stop events.
+ * ABOUTME: Never blocks; delegates the decision to the active skill's contract.
+ */
+
+const { observe } = require('./observe-gate');
+
+/**
+ * Entry point invoked by hook-runner with the raw stdin payload.
+ * @param {string} data
+ */
+function run(data) {
+  observe('stop-audit', data);
+}
+
+if (require.main === module) {
+  let input = '';
+  try {
+    input = require('fs').readFileSync(0, 'utf8');
+  } catch {
+    input = '';
+  }
+  run(input);
+  process.exit(0);
+}
+
+module.exports = { run };

--- a/lib/active-skill.js
+++ b/lib/active-skill.js
@@ -1,0 +1,140 @@
+'use strict';
+
+/**
+ * Active-skill marker lifecycle.
+ *
+ * The active-skill marker lives at .envoy/active-skill.json and signals which
+ * rigid skill currently owns the session. Left unmanaged, a stale marker turns
+ * into a global tripwire — Stop-audit keeps reacting to a skill that finished
+ * long ago, on a different branch, or in an unrelated session.
+ *
+ * This module gives the marker a lifecycle: it is stamped with the branch,
+ * session, and start time it was written under, and reads that go stale on any
+ * of those axes (or an explicit clear) return null instead of a live marker.
+ *
+ * Zero external dependencies. Branch and session are injectable so callers can
+ * test hermetically without touching the real repo's git state or clock.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const MARKER_REL = path.join('.envoy', 'active-skill.json');
+
+/** Default staleness window: 4 hours. */
+const DEFAULT_TTL_MS = 4 * 60 * 60 * 1000;
+
+/**
+ * Resolve the marker path under a working directory.
+ * @param {string} dir
+ * @returns {string}
+ */
+function markerPath(dir) {
+  return path.join(dir, MARKER_REL);
+}
+
+/**
+ * Current git branch for a directory, or 'unknown' when git is unavailable.
+ * @param {string} dir
+ * @returns {string}
+ */
+function currentBranch(dir) {
+  try {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch (_err) {
+    return 'unknown';
+  }
+}
+
+/**
+ * Session identifier for the running process. Prefers CLAUDE_SESSION_ID, else a
+ * stable-per-process token derived from the PID.
+ * @returns {string}
+ */
+function currentSession() {
+  return process.env.CLAUDE_SESSION_ID || `pid-${process.pid}`;
+}
+
+/**
+ * Write the active-skill marker, stamping lifecycle fields alongside `meta`.
+ * @param {string} dir - Working directory root (marker written under dir/.envoy).
+ * @param {{skill: string, issueNumber?: number}} meta
+ * @param {{now?: Date, branch?: string, session?: string}} [opts]
+ */
+function writeActiveSkill(dir, meta, opts = {}) {
+  const now = opts.now || new Date();
+  const branch = opts.branch !== undefined ? opts.branch : currentBranch(dir);
+  const session = opts.session !== undefined ? opts.session : currentSession();
+
+  const marker = {
+    $schemaVersion: '1',
+    skill: meta.skill,
+    startedAt: now.toISOString(),
+    branch,
+    session,
+    pid: process.pid,
+  };
+  if (meta.issueNumber !== undefined && meta.issueNumber !== null) {
+    marker.issueNumber = Number(meta.issueNumber);
+  }
+
+  const full = markerPath(dir);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, JSON.stringify(marker, null, 2));
+}
+
+/**
+ * Read the active-skill marker, or null when it is missing, unparseable, or
+ * stale. Stale ⇔ older than the TTL, or written under a different branch or
+ * session than the current one.
+ * @param {string} dir
+ * @param {{now?: Date, branch?: string, session?: string, ttlMs?: number}} [opts]
+ * @returns {object|null}
+ */
+function readActiveSkill(dir, opts = {}) {
+  let marker;
+  try {
+    marker = JSON.parse(fs.readFileSync(markerPath(dir), 'utf8'));
+  } catch (_err) {
+    return null;
+  }
+
+  const now = opts.now || new Date();
+  const branch = opts.branch !== undefined ? opts.branch : currentBranch(dir);
+  const session = opts.session !== undefined ? opts.session : currentSession();
+  const ttlMs = opts.ttlMs !== undefined ? opts.ttlMs : DEFAULT_TTL_MS;
+
+  const startedAt = Date.parse(marker.startedAt);
+  if (Number.isNaN(startedAt) || now.getTime() - startedAt > ttlMs) {
+    return null;
+  }
+  if (marker.branch !== branch) return null;
+  if (marker.session !== session) return null;
+
+  return marker;
+}
+
+/**
+ * Remove the active-skill marker. No-op (no throw) when already absent.
+ * @param {string} dir
+ */
+function clearActiveSkill(dir) {
+  try {
+    fs.unlinkSync(markerPath(dir));
+  } catch (_err) {
+    // Already gone — the desired end state either way.
+  }
+}
+
+module.exports = {
+  writeActiveSkill,
+  readActiveSkill,
+  clearActiveSkill,
+  DEFAULT_TTL_MS,
+  MARKER_REL,
+};

--- a/lib/active-skill.js
+++ b/lib/active-skill.js
@@ -136,5 +136,4 @@ module.exports = {
   readActiveSkill,
   clearActiveSkill,
   DEFAULT_TTL_MS,
-  MARKER_REL,
 };

--- a/lib/contract-guard.js
+++ b/lib/contract-guard.js
@@ -66,50 +66,49 @@ function validatePrompt(invariant, toolInput) {
 }
 
 /**
- * Run the PreToolUse[Agent] guard.
+ * Decide whether a parsed Agent event would violate the contract, WITHOUT
+ * touching stdin or exiting. Callers get the decision and can enforce (exit 2)
+ * or observe (log) as they see fit.
  * @param {string} contractPath absolute path to contract.json
- * @returns {number} exit code (0 allow, 2 block)
+ * @param {object} event the parsed PreToolUse event
+ * @returns {{block: boolean, skill?: string, tool?: string, reason?: string, errors?: string[]}}
  */
-function runAgentGuard(contractPath) {
-  const raw = readStdin();
-  if (!raw) return 0;
-  let event;
-  try {
-    event = JSON.parse(raw);
-  } catch {
-    return 0;
-  }
+function evaluateAgentGuard(contractPath, event) {
   const toolName = event.tool_name || event.toolName;
-  if (toolName !== 'Agent') return 0;
+  if (toolName !== 'Agent') return { block: false };
 
   const contract = loadContract(contractPath);
-  if (!contract) return 0;
+  if (!contract) return { block: false };
 
   const toolInput = event.tool_input || event.toolInput || {};
   const prompt = toolInput.prompt || '';
   const inv = findInvariantMatch(contract.agentInvariants, prompt);
-  if (!inv) return 0;
+  if (!inv) return { block: false };
 
   const errors = validatePrompt(inv, toolInput);
-  if (errors.length === 0) return 0;
+  if (errors.length === 0) return { block: false };
 
-  process.stderr.write(`agent-guard (${contract.skill}): blocked — ${inv.matchPrompt}\n`);
-  for (const e of errors) process.stderr.write(`  - ${e}\n`);
-  return 2;
+  return {
+    block: true,
+    skill: contract.skill,
+    tool: toolName,
+    reason: `${inv.matchPrompt}: ${errors.join('; ')}`,
+    errors,
+  };
 }
 
 /**
- * Run the Stop-audit hook.
- * Ensures requiredArtifacts exist (relative to cwd) and that any
- * loopSignals referenced are in a confirmed state.
+ * Decide whether a Stop event would violate the contract, WITHOUT exiting.
+ * Checks requiredArtifacts existence/commit state and loopSignal confirmation.
+ * @param {string} contractPath absolute path to contract.json
+ * @param {string} [cwd] working directory to resolve artifacts/loops against
+ * @returns {{block: boolean, skill?: string, reason?: string, missing?: string[], loopIssues?: string[]}}
  */
-function runStopAudit(contractPath) {
+function evaluateStopAudit(contractPath, cwd = process.cwd()) {
   const contract = loadContract(contractPath);
-  if (!contract) return 0;
+  if (!contract) return { block: false };
 
-  const cwd = process.cwd();
   const missing = [];
-
   for (const art of contract.requiredArtifacts || []) {
     const p = path.join(cwd, art.path);
     if (!fs.existsSync(p)) {
@@ -141,18 +140,56 @@ function runStopAudit(contractPath) {
     if (r.status !== 0) loopIssues.push(`${loopName}: status pending (${(r.stdout || '').trim()})`);
   }
 
-  if (missing.length === 0 && loopIssues.length === 0) return 0;
+  if (missing.length === 0 && loopIssues.length === 0) return { block: false };
 
-  process.stderr.write(`stop-audit (${contract.skill}): blocked\n`);
-  if (missing.length) {
-    process.stderr.write('missing artifacts:\n');
-    for (const m of missing) process.stderr.write(`  - ${m}\n`);
+  const parts = [];
+  if (missing.length) parts.push(`missing artifacts: ${missing.join(', ')}`);
+  if (loopIssues.length) parts.push(`loop signals: ${loopIssues.join(', ')}`);
+
+  return { block: true, skill: contract.skill, reason: parts.join('; '), missing, loopIssues };
+}
+
+/**
+ * Run the PreToolUse[Agent] guard (reads stdin, enforces with exit code).
+ * @param {string} contractPath absolute path to contract.json
+ * @returns {number} exit code (0 allow, 2 block)
+ */
+function runAgentGuard(contractPath) {
+  const raw = readStdin();
+  if (!raw) return 0;
+  let event;
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    return 0;
   }
-  if (loopIssues.length) {
-    process.stderr.write('loop signals:\n');
-    for (const l of loopIssues) process.stderr.write(`  - ${l}\n`);
-  }
+
+  const decision = evaluateAgentGuard(contractPath, event);
+  if (!decision.block) return 0;
+
+  process.stderr.write(`agent-guard (${decision.skill}): blocked — ${decision.reason}\n`);
   return 2;
 }
 
-module.exports = { runAgentGuard, runStopAudit, findInvariantMatch, validatePrompt, loadContract };
+/**
+ * Run the Stop-audit hook (enforces with exit code).
+ * Ensures requiredArtifacts exist (relative to cwd) and that any
+ * loopSignals referenced are in a confirmed state.
+ */
+function runStopAudit(contractPath) {
+  const decision = evaluateStopAudit(contractPath, process.cwd());
+  if (!decision.block) return 0;
+
+  process.stderr.write(`stop-audit (${decision.skill}): blocked — ${decision.reason}\n`);
+  return 2;
+}
+
+module.exports = {
+  runAgentGuard,
+  runStopAudit,
+  evaluateAgentGuard,
+  evaluateStopAudit,
+  findInvariantMatch,
+  validatePrompt,
+  loadContract,
+};

--- a/lib/schemas/active-skill.json
+++ b/lib/schemas/active-skill.json
@@ -9,6 +9,7 @@
     "skill": { "type": "string" },
     "issueNumber": { "type": "number" },
     "branch": { "type": "string" },
+    "session": { "type": "string" },
     "startedAt": { "type": "string" },
     "pid": { "type": "number" }
   }

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -11,14 +11,6 @@ allowed-tools:
   - Grep
   - Glob
   - Skill
-hooks:
-  PreToolUse:
-    - matcher: Agent
-      command: node ${CLAUDE_SKILL_DIR}/hooks/agent-guard.js
-      once: true
-  Stop:
-    - command: node ${CLAUDE_SKILL_DIR}/hooks/stop-audit.js
-      once: true
 ---
 
 ## Briefing

--- a/skills/cleanup/contract.json
+++ b/skills/cleanup/contract.json
@@ -1,9 +1,7 @@
 {
   "skill": "cleanup",
   "agentInvariants": [],
-  "requiredArtifacts": [
-    { "path": ".envoy/active-skill.json", "committed": false }
-  ],
+  "requiredArtifacts": [],
   "loopSignals": [],
   "handoffOut": null
 }

--- a/skills/cleanup/preflight.js
+++ b/skills/cleanup/preflight.js
@@ -5,38 +5,31 @@
  * Cleanup preflight (stub).
  *
  * Cleanup runs after merge; it tolerates missing state (that's the point —
- * we're about to remove it). Mainly, we write the active-skill marker so
- * Stop-audit can tell the difference between "cleanup is running" and
- * "something else wandered into .worktrees/".
+ * we're about to remove it). It is also the active-skill marker's explicit
+ * clear point: whatever skill last owned the session is done, so we drop the
+ * marker rather than leave it as a stale global tripwire.
  */
 
 const fs = require('fs');
 const path = require('path');
 
 const CWD = process.cwd();
+const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..');
+const { readActiveSkill, clearActiveSkill } = require(path.join(REPO_ROOT, 'lib', 'active-skill'));
 
 function say(line) { process.stdout.write(`${line}\n`); }
 function banner(tier) { say(`## STATUS: ${tier}`); }
 
-function writeJson(rel, data) {
-  const full = path.join(CWD, rel);
-  fs.mkdirSync(path.dirname(full), { recursive: true });
-  fs.writeFileSync(full, JSON.stringify(data, null, 2));
-}
-
-function nowIso() { return new Date().toISOString(); }
-
 function main() {
-  writeJson('.envoy/active-skill.json', {
-    $schemaVersion: '1',
-    skill: 'cleanup',
-    startedAt: nowIso(),
-    pid: process.pid,
-  });
+  const priorMarker = readActiveSkill(CWD);
+  clearActiveSkill(CWD);
 
   const statePath = path.join(CWD, '.envoy', 'finalize', 'state.json');
   banner('ok');
   say('');
+  if (priorMarker) {
+    say(`Cleared active-skill marker (was: ${priorMarker.skill}).`);
+  }
   if (fs.existsSync(statePath)) {
     try {
       const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));

--- a/skills/coderabbit-pr-review/SKILL.md
+++ b/skills/coderabbit-pr-review/SKILL.md
@@ -14,14 +14,6 @@ allowed-tools:
   - Glob
   - Skill
   - WebFetch
-hooks:
-  PreToolUse:
-    - matcher: Agent
-      command: node ${CLAUDE_SKILL_DIR}/hooks/agent-guard.js
-      once: true
-  Stop:
-    - command: node ${CLAUDE_SKILL_DIR}/hooks/stop-audit.js
-      once: true
 ---
 
 ## Briefing

--- a/skills/finalize/SKILL.md
+++ b/skills/finalize/SKILL.md
@@ -15,14 +15,6 @@ allowed-tools:
   - Skill
   - WebFetch
 context: fork
-hooks:
-  PreToolUse:
-    - matcher: Agent
-      command: node ${CLAUDE_SKILL_DIR}/hooks/agent-guard.js
-      once: true
-  Stop:
-    - command: node ${CLAUDE_SKILL_DIR}/hooks/stop-audit.js
-      once: true
 ---
 
 ## Briefing

--- a/skills/fix-ci/SKILL.md
+++ b/skills/fix-ci/SKILL.md
@@ -14,14 +14,6 @@ allowed-tools:
   - Glob
   - Skill
   - WebFetch
-hooks:
-  PreToolUse:
-    - matcher: Agent
-      command: node ${CLAUDE_SKILL_DIR}/hooks/agent-guard.js
-      once: true
-  Stop:
-    - command: node ${CLAUDE_SKILL_DIR}/hooks/stop-audit.js
-      once: true
 ---
 
 ## Briefing

--- a/skills/pickup/SKILL.md
+++ b/skills/pickup/SKILL.md
@@ -14,14 +14,6 @@ allowed-tools:
   - Glob
   - Skill
   - Agent
-hooks:
-  PreToolUse:
-    - matcher: Agent
-      command: node ${CLAUDE_SKILL_DIR}/hooks/agent-guard.js
-      once: true
-  Stop:
-    - command: node ${CLAUDE_SKILL_DIR}/hooks/stop-audit.js
-      once: true
 ---
 
 ## Briefing

--- a/skills/pickup/preflight.js
+++ b/skills/pickup/preflight.js
@@ -21,6 +21,7 @@ const CWD = process.cwd();
 const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..');
 const { validateFile } = require(path.join(REPO_ROOT, 'lib', 'validate-schema'));
 const { extractEmbeddedBlock } = require(path.join(REPO_ROOT, 'lib', 'tasks-embed'));
+const { writeActiveSkill } = require(path.join(REPO_ROOT, 'lib', 'active-skill'));
 
 // Best-effort fetch of an issue body via gh. Returns the body string, or null
 // when gh is unavailable or the call fails — callers must tolerate null.
@@ -66,16 +67,6 @@ function writeJson(rel, data) {
 }
 
 function nowIso() { return new Date().toISOString(); }
-
-function writeActiveSkill(issueNumber) {
-  writeJson('.envoy/active-skill.json', {
-    $schemaVersion: '1',
-    skill: 'pickup',
-    issueNumber: issueNumber ? Number(issueNumber) : undefined,
-    startedAt: nowIso(),
-    pid: process.pid,
-  });
-}
 
 function main() {
   const issueNumber = process.env.ENVOY_ISSUE_NUMBER;
@@ -150,7 +141,7 @@ function main() {
     nextSteps: [],
   };
   writeJson('.envoy/pickup/session.json', session);
-  writeActiveSkill(issueNumber);
+  writeActiveSkill(CWD, { skill: 'pickup', issueNumber: issueNumber ? Number(issueNumber) : undefined });
 
   const tier = strictPromote(materialized ? 'degraded' : 'ok');
   banner(tier);

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -18,14 +18,6 @@ allowed-tools:
   - WebFetch
 model: opus
 context: fork
-hooks:
-  PreToolUse:
-    - matcher: Agent
-      command: node ${CLAUDE_SKILL_DIR}/hooks/agent-guard.js
-      once: true
-  Stop:
-    - command: node ${CLAUDE_SKILL_DIR}/hooks/stop-audit.js
-      once: true
 ---
 
 ## Briefing

--- a/skills/wiki-sync/SKILL.md
+++ b/skills/wiki-sync/SKILL.md
@@ -14,14 +14,6 @@ allowed-tools:
   - Bash
   - Grep
   - Glob
-hooks:
-  PreToolUse:
-    - matcher: Agent
-      command: node ${CLAUDE_SKILL_DIR}/hooks/agent-guard.js
-      once: true
-  Stop:
-    - command: node ${CLAUDE_SKILL_DIR}/hooks/stop-audit.js
-      once: true
 ---
 
 ## Briefing

--- a/tests/hooks/observe-gates.test.js
+++ b/tests/hooks/observe-gates.test.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * Plugin-level observe-mode gates — agent-guard and stop-audit.
+ *
+ * Proves the gates register at plugin level (hooks/hooks.json) and run in
+ * OBSERVE mode: they resolve the active skill's contract, log a would-block
+ * decision to .envoy/observe-log.jsonl, and ALWAYS exit 0 (fail-open on any
+ * error, no-op when no rigid skill is active).
+ *
+ * Run: node tests/hooks/observe-gates.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const HOOKS_JSON = path.join(REPO_ROOT, 'hooks', 'hooks.json');
+const AGENT_GUARD = path.join(REPO_ROOT, 'hooks', 'agent-guard.js');
+const STOP_AUDIT = path.join(REPO_ROOT, 'hooks', 'stop-audit.js');
+const OBSERVE_LOG = path.join('.envoy', 'observe-log.jsonl');
+
+const SESSION = 'observe-gates-test-session';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'observe-gates-'));
+}
+
+/** Write a fresh, non-stale active-skill marker for `skill` under `cwd`. */
+function writeMarker(cwd, skill) {
+  fs.mkdirSync(path.join(cwd, '.envoy'), { recursive: true });
+  fs.writeFileSync(
+    path.join(cwd, '.envoy', 'active-skill.json'),
+    JSON.stringify({
+      $schemaVersion: '1',
+      skill,
+      startedAt: new Date().toISOString(),
+      branch: 'unknown', // temp dir is not a git repo → currentBranch() === 'unknown'
+      session: SESSION,
+      pid: process.pid,
+    })
+  );
+}
+
+function runGate(gateScript, cwd, input) {
+  return spawnSync('node', [gateScript], {
+    cwd,
+    encoding: 'utf8',
+    input: typeof input === 'string' ? input : JSON.stringify(input || {}),
+    env: { ...process.env, CLAUDE_SESSION_ID: SESSION },
+  });
+}
+
+function readLog(cwd) {
+  const p = path.join(cwd, OBSERVE_LOG);
+  if (!fs.existsSync(p)) return null;
+  return fs
+    .readFileSync(p, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+const blockingAgentEvent = {
+  tool_name: 'Agent',
+  tool_input: {
+    subagent_type: 'general-purpose',
+    description: 'Implement Task 1',
+    prompt: 'Implement Task 1: add feature\n\n(missing both Iron Law tokens)',
+  },
+};
+
+section('registration: plugin-level gates in hooks/hooks.json');
+
+const hooksConfig = JSON.parse(fs.readFileSync(HOOKS_JSON, 'utf8'));
+
+test('PreToolUse registers matcher "Agent" → agent-guard via hook-runner', () => {
+  const pre = hooksConfig.hooks.PreToolUse || [];
+  const agentEntry = pre.find((e) => e.matcher === 'Agent');
+  assert.ok(agentEntry, 'no PreToolUse entry with matcher "Agent"');
+  const cmd = agentEntry.hooks.map((h) => h.command).join(' ');
+  assert.ok(/hook-runner\.js" agent-guard/.test(cmd), `agent-guard not wired via hook-runner: ${cmd}`);
+});
+
+test('Stop registers stop-audit via hook-runner', () => {
+  const stop = hooksConfig.hooks.Stop || [];
+  const cmd = stop.flatMap((e) => e.hooks.map((h) => h.command)).join(' ');
+  assert.ok(/hook-runner\.js" stop-audit/.test(cmd), `stop-audit not wired via hook-runner: ${cmd}`);
+});
+
+section('observe mode: would-block scenarios log and exit 0');
+
+test('agent-guard logs a would-block record and exits 0', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent);
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    const log = readLog(tmp);
+    assert.ok(log && log.length === 1, 'expected exactly one observe-log record');
+    const rec = log[0];
+    assert.strictEqual(rec.skill, 'pickup');
+    assert.strictEqual(rec.gate, 'agent-guard');
+    assert.strictEqual(rec.tool, 'Agent');
+    assert.ok(typeof rec.ts === 'string' && rec.ts.length > 0, 'ts must be present');
+    assert.ok(typeof rec.reason === 'string' && rec.reason.length > 0, 'reason must be present');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('stop-audit logs a would-block record and exits 0', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup'); // pickup requires session.json + handoff which are absent
+    const r = runGate(STOP_AUDIT, tmp, {});
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    const log = readLog(tmp);
+    assert.ok(log && log.length === 1, 'expected exactly one observe-log record');
+    assert.strictEqual(log[0].skill, 'pickup');
+    assert.strictEqual(log[0].gate, 'stop-audit');
+    assert.ok(/session\.json|handoff-to-review/.test(log[0].reason), 'reason must name missing artifacts');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+section('fail-open and no-op paths always exit 0');
+
+test('malformed stdin → exit 0, no crash', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runGate(AGENT_GUARD, tmp, 'not json {{{');
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('no active skill → exit 0 and no observe-log written', () => {
+  const tmp = mkTmp();
+  try {
+    // no marker written
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent);
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    assert.strictEqual(readLog(tmp), null, 'no observe-log should exist when no skill is active');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('stop-audit with no active skill → exit 0 and no log', () => {
+  const tmp = mkTmp();
+  try {
+    const r = runGate(STOP_AUDIT, tmp, {});
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    assert.strictEqual(readLog(tmp), null, 'no observe-log should exist when no skill is active');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+section('cleanup: dead per-skill hooks frontmatter removed');
+
+for (const skill of ['cleanup', 'finalize', 'coderabbit-pr-review', 'fix-ci', 'pickup', 'review', 'wiki-sync']) {
+  test(`${skill}/SKILL.md has no hooks: frontmatter block`, () => {
+    const md = fs.readFileSync(path.join(REPO_ROOT, 'skills', skill, 'SKILL.md'), 'utf8');
+    const fm = md.split(/^---$/m)[1] || '';
+    assert.ok(!/^hooks:/m.test(fm), `${skill}/SKILL.md still declares a hooks: frontmatter block`);
+  });
+}
+
+process.stdout.write(`\n\x1b[1m${passed} passed, ${failed} failed\x1b[0m\n`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/lib/active-skill.test.js
+++ b/tests/lib/active-skill.test.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Active-skill marker lifecycle — Test Suite
+ *
+ * Run: node tests/lib/active-skill.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const LIB = path.join(__dirname, '..', '..', 'lib');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function markerPath(dir) {
+  return path.join(dir, '.envoy', 'active-skill.json');
+}
+
+function readRaw(dir) {
+  return JSON.parse(fs.readFileSync(markerPath(dir), 'utf8'));
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Load module + schema validator
+// ═══════════════════════════════════════════════════════════════════
+
+const activeSkill = require(path.join(LIB, 'active-skill'));
+const { validate } = require(path.join(LIB, 'validate-schema'));
+
+// ═══════════════════════════════════════════════════════════════════
+// Exports
+// ═══════════════════════════════════════════════════════════════════
+
+section('exports');
+
+test('writeActiveSkill is exported', () => {
+  assert.strictEqual(typeof activeSkill.writeActiveSkill, 'function');
+});
+
+test('readActiveSkill is exported', () => {
+  assert.strictEqual(typeof activeSkill.readActiveSkill, 'function');
+});
+
+test('clearActiveSkill is exported', () => {
+  assert.strictEqual(typeof activeSkill.clearActiveSkill, 'function');
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// writeActiveSkill
+// ═══════════════════════════════════════════════════════════════════
+
+section('writeActiveSkill: stamps meta + lifecycle fields');
+
+test('writes marker with skill, issueNumber, startedAt, branch, session', () => {
+  const dir = makeTmp('as-write-');
+  const now = new Date('2026-07-20T10:00:00.000Z');
+  activeSkill.writeActiveSkill(
+    dir,
+    { skill: 'pickup', issueNumber: 60 },
+    { now, branch: 'feature/60-observe-gates', session: 'sess-abc' }
+  );
+  const m = readRaw(dir);
+  assert.strictEqual(m.skill, 'pickup');
+  assert.strictEqual(m.issueNumber, 60);
+  assert.strictEqual(m.startedAt, '2026-07-20T10:00:00.000Z');
+  assert.strictEqual(m.branch, 'feature/60-observe-gates');
+  assert.strictEqual(m.session, 'sess-abc');
+  cleanup(dir);
+});
+
+test('written marker validates against active-skill schema', () => {
+  const dir = makeTmp('as-write-');
+  activeSkill.writeActiveSkill(
+    dir,
+    { skill: 'pickup', issueNumber: 60 },
+    { now: new Date(), branch: 'main', session: 'x' }
+  );
+  const result = validate('active-skill', readRaw(dir));
+  assert.ok(result.valid, `expected valid, errors: ${result.errors.join(', ')}`);
+  cleanup(dir);
+});
+
+test('omits issueNumber when absent (schema requires number when present)', () => {
+  const dir = makeTmp('as-write-');
+  activeSkill.writeActiveSkill(
+    dir,
+    { skill: 'cleanup' },
+    { now: new Date(), branch: 'main', session: 'x' }
+  );
+  const m = readRaw(dir);
+  assert.ok(!('issueNumber' in m), 'issueNumber should be omitted');
+  assert.ok(validate('active-skill', m).valid);
+  cleanup(dir);
+});
+
+test('creates .envoy directory if missing', () => {
+  const dir = makeTmp('as-write-');
+  assert.ok(!fs.existsSync(path.join(dir, '.envoy')));
+  activeSkill.writeActiveSkill(dir, { skill: 'pickup' }, { now: new Date(), branch: 'b', session: 's' });
+  assert.ok(fs.existsSync(markerPath(dir)));
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// readActiveSkill — fresh
+// ═══════════════════════════════════════════════════════════════════
+
+section('readActiveSkill: fresh marker round-trips');
+
+test('returns the marker when branch + session match and within TTL', () => {
+  const dir = makeTmp('as-read-');
+  const started = new Date('2026-07-20T10:00:00.000Z');
+  activeSkill.writeActiveSkill(dir, { skill: 'pickup', issueNumber: 60 }, {
+    now: started, branch: 'feat', session: 'sess-1',
+  });
+  const m = activeSkill.readActiveSkill(dir, {
+    now: new Date('2026-07-20T10:30:00.000Z'),
+    branch: 'feat',
+    session: 'sess-1',
+    ttlMs: 4 * 60 * 60 * 1000,
+  });
+  assert.ok(m, 'expected a marker');
+  assert.strictEqual(m.skill, 'pickup');
+  assert.strictEqual(m.issueNumber, 60);
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// readActiveSkill — stale
+// ═══════════════════════════════════════════════════════════════════
+
+section('readActiveSkill: stale ⇒ null');
+
+test('null when now - startedAt exceeds ttlMs', () => {
+  const dir = makeTmp('as-read-');
+  const started = new Date('2026-07-20T10:00:00.000Z');
+  activeSkill.writeActiveSkill(dir, { skill: 'pickup' }, {
+    now: started, branch: 'feat', session: 'sess-1',
+  });
+  const m = activeSkill.readActiveSkill(dir, {
+    now: new Date('2026-07-20T15:00:00.000Z'), // 5h later
+    branch: 'feat',
+    session: 'sess-1',
+    ttlMs: 4 * 60 * 60 * 1000, // 4h TTL
+  });
+  assert.strictEqual(m, null);
+  cleanup(dir);
+});
+
+test('null when marker branch differs from current branch', () => {
+  const dir = makeTmp('as-read-');
+  const started = new Date('2026-07-20T10:00:00.000Z');
+  activeSkill.writeActiveSkill(dir, { skill: 'pickup' }, {
+    now: started, branch: 'feat', session: 'sess-1',
+  });
+  const m = activeSkill.readActiveSkill(dir, {
+    now: new Date('2026-07-20T10:05:00.000Z'),
+    branch: 'main', // different branch
+    session: 'sess-1',
+    ttlMs: 4 * 60 * 60 * 1000,
+  });
+  assert.strictEqual(m, null);
+  cleanup(dir);
+});
+
+test('null when marker session differs from current session', () => {
+  const dir = makeTmp('as-read-');
+  const started = new Date('2026-07-20T10:00:00.000Z');
+  activeSkill.writeActiveSkill(dir, { skill: 'pickup' }, {
+    now: started, branch: 'feat', session: 'sess-1',
+  });
+  const m = activeSkill.readActiveSkill(dir, {
+    now: new Date('2026-07-20T10:05:00.000Z'),
+    branch: 'feat',
+    session: 'sess-2', // different session
+    ttlMs: 4 * 60 * 60 * 1000,
+  });
+  assert.strictEqual(m, null);
+  cleanup(dir);
+});
+
+test('uses default TTL when ttlMs not provided', () => {
+  const dir = makeTmp('as-read-');
+  const started = new Date('2026-07-20T10:00:00.000Z');
+  activeSkill.writeActiveSkill(dir, { skill: 'pickup' }, {
+    now: started, branch: 'feat', session: 'sess-1',
+  });
+  // 1 minute later, same branch/session — must be fresh under any sane default
+  const fresh = activeSkill.readActiveSkill(dir, {
+    now: new Date('2026-07-20T10:01:00.000Z'),
+    branch: 'feat',
+    session: 'sess-1',
+  });
+  assert.ok(fresh, 'expected fresh marker under default TTL');
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// readActiveSkill — missing / unparseable
+// ═══════════════════════════════════════════════════════════════════
+
+section('readActiveSkill: missing / unparseable ⇒ null (no throw)');
+
+test('null when marker file is missing', () => {
+  const dir = makeTmp('as-read-');
+  const m = activeSkill.readActiveSkill(dir, {
+    now: new Date(), branch: 'feat', session: 'x',
+  });
+  assert.strictEqual(m, null);
+  cleanup(dir);
+});
+
+test('null when marker file is unparseable', () => {
+  const dir = makeTmp('as-read-');
+  fs.mkdirSync(path.join(dir, '.envoy'), { recursive: true });
+  fs.writeFileSync(markerPath(dir), '{ not json', 'utf8');
+  let m;
+  assert.doesNotThrow(() => {
+    m = activeSkill.readActiveSkill(dir, { now: new Date(), branch: 'feat', session: 'x' });
+  });
+  assert.strictEqual(m, null);
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// clearActiveSkill
+// ═══════════════════════════════════════════════════════════════════
+
+section('clearActiveSkill: removes marker; no-throw when absent');
+
+test('removes an existing marker', () => {
+  const dir = makeTmp('as-clear-');
+  activeSkill.writeActiveSkill(dir, { skill: 'cleanup' }, { now: new Date(), branch: 'b', session: 's' });
+  assert.ok(fs.existsSync(markerPath(dir)));
+  activeSkill.clearActiveSkill(dir);
+  assert.ok(!fs.existsSync(markerPath(dir)), 'marker should be gone');
+  cleanup(dir);
+});
+
+test('does not throw when marker is already absent', () => {
+  const dir = makeTmp('as-clear-');
+  assert.doesNotThrow(() => activeSkill.clearActiveSkill(dir));
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Summary
+// ═══════════════════════════════════════════════════════════════════
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Foundational first step of Phase 3 (enforcement rearchitecture, #26). Spike A (#28) proved the per-skill `SKILL.md` frontmatter hooks silently **never register** — so `agent-guard`/`stop-audit` have never fired. This moves them to the **plugin level** (`hooks/hooks.json`, which does register) and runs them in **observe mode**: log would-block events, never block yet. It also gives `active-skill.json` a **lifecycle** so a stale marker can't become a global tripwire. **Closes #60.**

## Changes

**task-1 — `active-skill.json` lifecycle** (`lib/active-skill.js`):
- `writeActiveSkill` / `readActiveSkill` (returns null when stale by **TTL / branch / session**) / `clearActiveSkill` (no-throw if absent).
- pickup preflight writes via it; **cleanup clears** it (the explicit-clear point). Schema updated (`session`); the stale `active-skill.json` required-artifact removed from cleanup's contract (would have been a stop-audit landmine).
- 16 hermetic unit tests.

**task-2 — plugin-level observe gates**:
- `hooks/hooks.json` registers `PreToolUse` matcher `Agent` → agent-guard and `Stop` → stop-audit (via the existing `hook-runner.js` convention).
- `hooks/observe-gate.js` reads the (lifecycle-aware) active skill, resolves its `contract.json`, and in observe mode **appends a would-block record to `.envoy/observe-log.jsonl` and always exits 0** — including when the guard throws (**fail-open**) and when no skill is active.
- `lib/contract-guard.js` refactored to add non-exiting `evaluateAgentGuard`/`evaluateStopAudit` (return a decision); the enforcing `runAgentGuard`/`runStopAudit` delegate to them, exit-2 behavior unchanged (existing `tests/skills/hooks.test.js` still green).
- The dead `hooks:` frontmatter removed from all 7 rigid skills' `SKILL.md`.
- 14 behaviour tests (real gate scripts via child_process, assert exit 0 + log content + fail-open + no-op).

## Deferred to follow-on Phase 3 issues

- **Arm strict mode** (exit-2) after observe-log false-positive data — the observe gate flips to blocking, no per-skill wiring needed.
- **Remove the now-dead per-skill wrapper files** (`skills/*/hooks/{agent-guard,stop-audit}.js`, 12 files) and possibly the `run*` enforcing variants once strict lives on the plugin gate.
- Self-healing preflight, the real ledger + PreCompact snapshot, fatal-preflight blocking, the wording pass.

## Test Plan

- [x] `node scripts/run-tests.js` — 26 files green (incl. new `active-skill.test.js` 16, `observe-gates.test.js` 14, and pre-existing `skills/hooks.test.js`)
- [x] Fail-open verified: no reachable non-zero-exit path in the observe gate (every branch traced in review)

## Linked Issue

Closes #60

---

*Created with Envoy*
