### PR TITLE
chore: retire dead per-skill guard wrappers + run* (superseded by #60 plugin gates)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,14 +33,13 @@ Rigid skills are enforced by files, not prose. Each lives in its own folder:
 
 ```
 skills/<name>/
-├── SKILL.md              # body + frontmatter declaring hooks
+├── SKILL.md              # body + frontmatter (no hooks: block — enforcement is plugin-level)
 ├── preflight.js          # invoked inline via !`node ${CLAUDE_SKILL_DIR}/preflight.js`
-├── contract.json         # declarative rules read by the skill's own hooks
-├── hooks/
-│   ├── agent-guard.js    # PreToolUse[Agent] — validates subagent prompts
-│   └── stop-audit.js     # Stop — verifies required artifacts + loop signals
+├── contract.json         # declarative rules read by the plugin-level enforcement gates
 └── steps/ or layers/     # long-form content, one file per phase (SKILL.md under 500 lines)
 ```
+
+**Enforcement (plugin-level, observe mode):** `hooks/hooks.json` registers `PreToolUse[Agent]` → agent-guard and `Stop` → stop-audit at the plugin level (per-skill frontmatter hooks silently never registered). `hooks/observe-gate.js` reads `.envoy/active-skill.json` (lifecycle-aware via `lib/active-skill.js`), resolves the active skill's `contract.json`, evaluates the would-block decision (`lib/contract-guard.js` `evaluate*`), and in observe mode appends it to `.envoy/observe-log.jsonl` and exits 0 (fail-open). Arming exit-2 (strict) is deferred until observe-log data shows zero false positives.
 
 **Frontmatter primitives (in order):**
 - `name`, `description` (directive template: `<Skill> expert. ALWAYS invoke when… Do not…`)
@@ -49,7 +48,8 @@ skills/<name>/
 - `paths:` — glob for path-scoped activation (`docs/wiki/**`, etc.)
 - `model:` / `effort:` — optional per-skill tuning
 - `context: fork` — forks the conversation for pure task-shaped skills (review, finalize). Skip for skills with user-approval pauses (pickup).
-- `hooks:` — declares `PreToolUse[Agent]` → `hooks/agent-guard.js` and `Stop` → `hooks/stop-audit.js`, both with `once: true`.
+
+(No `hooks:` frontmatter — enforcement is registered once at the plugin level; see **Enforcement** above.)
 
 **Inline preflight pattern:** each rigid SKILL.md body opens with
 `## Briefing\n!`node ${CLAUDE_SKILL_DIR}/preflight.js``, immediately

--- a/lib/contract-guard.js
+++ b/lib/contract-guard.js
@@ -1,24 +1,15 @@
 'use strict';
 
 /**
- * Shared contract-guard logic used by per-skill PreToolUse[Agent] and
- * Stop hooks. Each skill's hook file is a thin wrapper that passes its
- * contract.json path into this module.
+ * Contract-guard decision logic. Given a skill's contract.json, evaluates
+ * whether an Agent tool call or a Stop event would violate the contract and
+ * returns the decision without exiting. The plugin observe-gate consumes these
+ * evaluators to log (and, in strict mode, block) violations.
  */
 
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
-
-function readStdin() {
-  let data = '';
-  try {
-    data = fs.readFileSync(0, 'utf8');
-  } catch {
-    // no stdin — fine for Stop hooks that don't need input
-  }
-  return data.trim();
-}
 
 function loadContract(contractPath) {
   if (!fs.existsSync(contractPath)) return null;
@@ -149,44 +140,7 @@ function evaluateStopAudit(contractPath, cwd = process.cwd()) {
   return { block: true, skill: contract.skill, reason: parts.join('; '), missing, loopIssues };
 }
 
-/**
- * Run the PreToolUse[Agent] guard (reads stdin, enforces with exit code).
- * @param {string} contractPath absolute path to contract.json
- * @returns {number} exit code (0 allow, 2 block)
- */
-function runAgentGuard(contractPath) {
-  const raw = readStdin();
-  if (!raw) return 0;
-  let event;
-  try {
-    event = JSON.parse(raw);
-  } catch {
-    return 0;
-  }
-
-  const decision = evaluateAgentGuard(contractPath, event);
-  if (!decision.block) return 0;
-
-  process.stderr.write(`agent-guard (${decision.skill}): blocked — ${decision.reason}\n`);
-  return 2;
-}
-
-/**
- * Run the Stop-audit hook (enforces with exit code).
- * Ensures requiredArtifacts exist (relative to cwd) and that any
- * loopSignals referenced are in a confirmed state.
- */
-function runStopAudit(contractPath) {
-  const decision = evaluateStopAudit(contractPath, process.cwd());
-  if (!decision.block) return 0;
-
-  process.stderr.write(`stop-audit (${decision.skill}): blocked — ${decision.reason}\n`);
-  return 2;
-}
-
 module.exports = {
-  runAgentGuard,
-  runStopAudit,
   evaluateAgentGuard,
   evaluateStopAudit,
   findInvariantMatch,

--- a/skills/coderabbit-pr-review/hooks/agent-guard.js
+++ b/skills/coderabbit-pr-review/hooks/agent-guard.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runAgentGuard } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runAgentGuard(path.join(__dirname, '..', 'contract.json')));

--- a/skills/coderabbit-pr-review/hooks/stop-audit.js
+++ b/skills/coderabbit-pr-review/hooks/stop-audit.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runStopAudit } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runStopAudit(path.join(__dirname, '..', 'contract.json')));

--- a/skills/finalize/hooks/agent-guard.js
+++ b/skills/finalize/hooks/agent-guard.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runAgentGuard } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runAgentGuard(path.join(__dirname, '..', 'contract.json')));

--- a/skills/finalize/hooks/stop-audit.js
+++ b/skills/finalize/hooks/stop-audit.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runStopAudit } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runStopAudit(path.join(__dirname, '..', 'contract.json')));

--- a/skills/fix-ci/hooks/agent-guard.js
+++ b/skills/fix-ci/hooks/agent-guard.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runAgentGuard } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runAgentGuard(path.join(__dirname, '..', 'contract.json')));

--- a/skills/fix-ci/hooks/stop-audit.js
+++ b/skills/fix-ci/hooks/stop-audit.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runStopAudit } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runStopAudit(path.join(__dirname, '..', 'contract.json')));

--- a/skills/pickup/hooks/agent-guard.js
+++ b/skills/pickup/hooks/agent-guard.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runAgentGuard } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runAgentGuard(path.join(__dirname, '..', 'contract.json')));

--- a/skills/pickup/hooks/stop-audit.js
+++ b/skills/pickup/hooks/stop-audit.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runStopAudit } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runStopAudit(path.join(__dirname, '..', 'contract.json')));

--- a/skills/review/hooks/agent-guard.js
+++ b/skills/review/hooks/agent-guard.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runAgentGuard } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runAgentGuard(path.join(__dirname, '..', 'contract.json')));

--- a/skills/review/hooks/stop-audit.js
+++ b/skills/review/hooks/stop-audit.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runStopAudit } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runStopAudit(path.join(__dirname, '..', 'contract.json')));

--- a/skills/wiki-sync/hooks/agent-guard.js
+++ b/skills/wiki-sync/hooks/agent-guard.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runAgentGuard } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runAgentGuard(path.join(__dirname, '..', 'contract.json')));

--- a/skills/wiki-sync/hooks/stop-audit.js
+++ b/skills/wiki-sync/hooks/stop-audit.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..', '..');
-const { runStopAudit } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
-process.exit(runStopAudit(path.join(__dirname, '..', 'contract.json')));

--- a/tests/skills/hooks.test.js
+++ b/tests/skills/hooks.test.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 /**
- * Per-skill hook tests — agent-guard and stop-audit for rigid skills.
+ * Contract-guard decision tests — evaluateAgentGuard and evaluateStopAudit
+ * for rigid skills. These exercise the pure decision logic directly (no
+ * process spawning / exit codes); the plugin observe-gate and future
+ * strict-mode consume the same functions.
  *
  * Run: node tests/skills/hooks.test.js
  */
@@ -9,9 +12,11 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const { spawnSync } = require('child_process');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
+process.env.ENVOY_REPO_ROOT = REPO_ROOT;
+
+const { evaluateAgentGuard, evaluateStopAudit } = require(path.join(REPO_ROOT, 'lib', 'contract-guard'));
 
 let passed = 0;
 let failed = 0;
@@ -35,21 +40,14 @@ function mkTmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-test-'));
 }
 
-function runHook(hookScript, cwd, input, env) {
-  return spawnSync('node', [hookScript], {
-    cwd,
-    encoding: 'utf8',
-    input: typeof input === 'string' ? input : JSON.stringify(input),
-    env: { ...process.env, ...env, ENVOY_REPO_ROOT: REPO_ROOT },
-  });
+function contractPath(skill) {
+  return path.join(REPO_ROOT, 'skills', skill, 'contract.json');
 }
 
-section('agent-guard: pickup — allows matching implementer prompt');
+section('evaluateAgentGuard: pickup — allows matching implementer prompt');
 
-test('implementer prompt with required tokens passes (exit 0)', () => {
-  const tmp = mkTmp();
-  const hook = path.join(REPO_ROOT, 'skills', 'pickup', 'hooks', 'agent-guard.js');
-  const input = {
+test('implementer prompt with required tokens is not blocked', () => {
+  const event = {
     tool_name: 'Agent',
     tool_input: {
       subagent_type: 'general-purpose',
@@ -57,15 +55,12 @@ test('implementer prompt with required tokens passes (exit 0)', () => {
       prompt: 'Implement Task 1: add feature\n\nScope Iron Law applies.\nTDD Iron Law applies.',
     },
   };
-  const r = runHook(hook, tmp, input);
-  assert.strictEqual(r.status, 0, `expected 0, got ${r.status}\n${r.stderr}`);
-  fs.rmSync(tmp, { recursive: true, force: true });
+  const d = evaluateAgentGuard(contractPath('pickup'), event);
+  assert.strictEqual(d.block, false, JSON.stringify(d));
 });
 
-test('implementer prompt missing TDD Iron Law fails (exit 2)', () => {
-  const tmp = mkTmp();
-  const hook = path.join(REPO_ROOT, 'skills', 'pickup', 'hooks', 'agent-guard.js');
-  const input = {
+test('implementer prompt missing TDD Iron Law is blocked', () => {
+  const event = {
     tool_name: 'Agent',
     tool_input: {
       subagent_type: 'general-purpose',
@@ -73,16 +68,13 @@ test('implementer prompt missing TDD Iron Law fails (exit 2)', () => {
       prompt: 'Implement Task 1: add feature\n\nScope Iron Law applies.\n(missing TDD rule)',
     },
   };
-  const r = runHook(hook, tmp, input);
-  assert.strictEqual(r.status, 2, `expected 2, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
-  assert.ok(/TDD Iron Law/.test(r.stderr + r.stdout));
-  fs.rmSync(tmp, { recursive: true, force: true });
+  const d = evaluateAgentGuard(contractPath('pickup'), event);
+  assert.strictEqual(d.block, true, JSON.stringify(d));
+  assert.ok(/TDD Iron Law/.test(d.reason), d.reason);
 });
 
-test('implementer prompt with wrong subagent type fails', () => {
-  const tmp = mkTmp();
-  const hook = path.join(REPO_ROOT, 'skills', 'pickup', 'hooks', 'agent-guard.js');
-  const input = {
+test('implementer prompt with wrong subagent type is blocked', () => {
+  const event = {
     tool_name: 'Agent',
     tool_input: {
       subagent_type: 'envoy:code-reviewer',
@@ -90,25 +82,19 @@ test('implementer prompt with wrong subagent type fails', () => {
       prompt: 'Implement Task 1: add feature\n\nScope Iron Law, TDD Iron Law.',
     },
   };
-  const r = runHook(hook, tmp, input);
-  assert.strictEqual(r.status, 2, `expected 2, got ${r.status}`);
-  assert.ok(/subagent_type|subagentType|general-purpose/.test(r.stderr + r.stdout));
-  fs.rmSync(tmp, { recursive: true, force: true });
+  const d = evaluateAgentGuard(contractPath('pickup'), event);
+  assert.strictEqual(d.block, true, JSON.stringify(d));
+  assert.ok(/subagent_type|subagentType|general-purpose/.test(d.reason), d.reason);
 });
 
-test('non-Agent tool calls pass through without inspection', () => {
-  const tmp = mkTmp();
-  const hook = path.join(REPO_ROOT, 'skills', 'pickup', 'hooks', 'agent-guard.js');
-  const input = { tool_name: 'Bash', tool_input: { command: 'ls' } };
-  const r = runHook(hook, tmp, input);
-  assert.strictEqual(r.status, 0);
-  fs.rmSync(tmp, { recursive: true, force: true });
+test('non-Agent tool calls are not blocked', () => {
+  const event = { tool_name: 'Bash', tool_input: { command: 'ls' } };
+  const d = evaluateAgentGuard(contractPath('pickup'), event);
+  assert.strictEqual(d.block, false, JSON.stringify(d));
 });
 
-test('Agent prompt with no matching invariant passes through', () => {
-  const tmp = mkTmp();
-  const hook = path.join(REPO_ROOT, 'skills', 'pickup', 'hooks', 'agent-guard.js');
-  const input = {
+test('Agent prompt with no matching invariant is not blocked', () => {
+  const event = {
     tool_name: 'Agent',
     tool_input: {
       subagent_type: 'general-purpose',
@@ -116,17 +102,14 @@ test('Agent prompt with no matching invariant passes through', () => {
       prompt: 'Look up a fact for me — not an implementer prompt',
     },
   };
-  const r = runHook(hook, tmp, input);
-  assert.strictEqual(r.status, 0);
-  fs.rmSync(tmp, { recursive: true, force: true });
+  const d = evaluateAgentGuard(contractPath('pickup'), event);
+  assert.strictEqual(d.block, false, JSON.stringify(d));
 });
 
-section('agent-guard: review — code-reviewer must read iterative-retrieval');
+section('evaluateAgentGuard: review — code-reviewer must read iterative-retrieval');
 
-test('code-reviewer prompt missing iterative-retrieval fails', () => {
-  const tmp = mkTmp();
-  const hook = path.join(REPO_ROOT, 'skills', 'review', 'hooks', 'agent-guard.js');
-  const input = {
+test('code-reviewer prompt missing iterative-retrieval is blocked', () => {
+  const event = {
     tool_name: 'Agent',
     tool_input: {
       subagent_type: 'envoy:code-reviewer',
@@ -134,16 +117,13 @@ test('code-reviewer prompt missing iterative-retrieval fails', () => {
       prompt: 'Run AI code review\n\ngit diff main...HEAD\n(retrieval protocol not referenced)',
     },
   };
-  const r = runHook(hook, tmp, input);
-  assert.strictEqual(r.status, 2, `expected 2, got ${r.status}\nstdout: ${r.stdout}`);
-  assert.ok(/iterative-retrieval/.test(r.stderr + r.stdout));
-  fs.rmSync(tmp, { recursive: true, force: true });
+  const d = evaluateAgentGuard(contractPath('review'), event);
+  assert.strictEqual(d.block, true, JSON.stringify(d));
+  assert.ok(/iterative-retrieval/.test(d.reason), d.reason);
 });
 
-test('code-reviewer prompt with all required tokens passes', () => {
-  const tmp = mkTmp();
-  const hook = path.join(REPO_ROOT, 'skills', 'review', 'hooks', 'agent-guard.js');
-  const input = {
+test('code-reviewer prompt with all required tokens is not blocked', () => {
+  const event = {
     tool_name: 'Agent',
     tool_input: {
       subagent_type: 'envoy:code-reviewer',
@@ -151,60 +131,55 @@ test('code-reviewer prompt with all required tokens passes', () => {
       prompt: 'Read contexts/iterative-retrieval.md first. Read-only review. Run git diff main...HEAD.',
     },
   };
-  const r = runHook(hook, tmp, input);
-  assert.strictEqual(r.status, 0);
-  fs.rmSync(tmp, { recursive: true, force: true });
+  const d = evaluateAgentGuard(contractPath('review'), event);
+  assert.strictEqual(d.block, false, JSON.stringify(d));
 });
 
-section('stop-audit: pickup — requires session.json and handoff');
+section('evaluateStopAudit: pickup — requires session.json and handoff');
 
-test('stop-audit fails when required artifacts are missing', () => {
+test('stop-audit blocks when required artifacts are missing', () => {
   const tmp = mkTmp();
-  const hook = path.join(REPO_ROOT, 'skills', 'pickup', 'hooks', 'stop-audit.js');
-  const r = runHook(hook, tmp, {});
-  assert.strictEqual(r.status, 2, `expected 2, got ${r.status}`);
-  assert.ok(/session\.json|handoff-to-review/.test(r.stderr + r.stdout));
+  const d = evaluateStopAudit(contractPath('pickup'), tmp);
+  assert.strictEqual(d.block, true, JSON.stringify(d));
+  assert.ok(/session\.json|handoff-to-review/.test(d.reason), d.reason);
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-test('stop-audit passes when all required artifacts exist', () => {
+test('stop-audit does not block when all required artifacts exist', () => {
   const tmp = mkTmp();
   fs.mkdirSync(path.join(tmp, '.envoy', 'pickup'), { recursive: true });
   fs.writeFileSync(path.join(tmp, '.envoy', 'active-skill.json'), '{}');
   fs.writeFileSync(path.join(tmp, '.envoy', 'pickup', 'session.json'), '{}');
   fs.writeFileSync(path.join(tmp, '.envoy', 'pickup', 'handoff-to-review.json'), '{}');
-  const hook = path.join(REPO_ROOT, 'skills', 'pickup', 'hooks', 'stop-audit.js');
-  const r = runHook(hook, tmp, {});
-  assert.strictEqual(r.status, 0, `expected 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+  const d = evaluateStopAudit(contractPath('pickup'), tmp);
+  assert.strictEqual(d.block, false, JSON.stringify(d));
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-section('stop-audit: fix-ci — checks loop status via loop-safeguards');
+section('evaluateStopAudit: fix-ci — checks loop status via loop-safeguards');
 
-test('stop-audit exits 2 when fix-ci loop has no confirmation', () => {
+test('stop-audit blocks when fix-ci loop has no confirmation', () => {
   const tmp = mkTmp();
   fs.mkdirSync(path.join(tmp, '.envoy', 'loops'), { recursive: true });
   fs.writeFileSync(path.join(tmp, '.envoy', 'active-skill.json'), '{}');
   fs.writeFileSync(path.join(tmp, '.envoy', 'loops', 'fix-ci.json'), JSON.stringify({
     loop: 'fix-ci', confirmed: 1, maxCycles: 3, cyclesSeen: 1, history: [],
   }));
-  const hook = path.join(REPO_ROOT, 'skills', 'fix-ci', 'hooks', 'stop-audit.js');
-  const r = runHook(hook, tmp, {});
-  assert.strictEqual(r.status, 2, `expected 2, got ${r.status}\n${r.stdout}`);
-  assert.ok(/fix-ci|loop|pending/i.test(r.stderr + r.stdout));
+  const d = evaluateStopAudit(contractPath('fix-ci'), tmp);
+  assert.strictEqual(d.block, true, JSON.stringify(d));
+  assert.ok(/fix-ci|loop|pending/i.test(d.reason), d.reason);
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-test('stop-audit exits 0 when fix-ci loop reached 3 confirmations', () => {
+test('stop-audit does not block when fix-ci loop reached 3 confirmations', () => {
   const tmp = mkTmp();
   fs.mkdirSync(path.join(tmp, '.envoy', 'loops'), { recursive: true });
   fs.writeFileSync(path.join(tmp, '.envoy', 'active-skill.json'), '{}');
   fs.writeFileSync(path.join(tmp, '.envoy', 'loops', 'fix-ci.json'), JSON.stringify({
     loop: 'fix-ci', confirmed: 3, maxCycles: 3, cyclesSeen: 3, history: [],
   }));
-  const hook = path.join(REPO_ROOT, 'skills', 'fix-ci', 'hooks', 'stop-audit.js');
-  const r = runHook(hook, tmp, {});
-  assert.strictEqual(r.status, 0, `expected 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+  const d = evaluateStopAudit(contractPath('fix-ci'), tmp);
+  assert.strictEqual(d.block, false, JSON.stringify(d));
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
Follow-up to #60/#61. Now that enforcement runs at the plugin level (observe gates), the old per-skill machinery is dead:

- **Deleted** the 12 wrapper files `skills/*/hooks/{agent-guard,stop-audit}.js` (their SKILL.md registration was already removed in #60; nothing invoked them).
- **Removed** `runAgentGuard`/`runStopAudit` (+ orphaned `readStdin`) from `lib/contract-guard.js` — used only by those wrappers. The decision logic lives on in the non-exiting `evaluateAgentGuard`/`evaluateStopAudit` (used by the plugin observe-gate and future strict-mode).
- **Retargeted** `tests/skills/hooks.test.js` to call `evaluate*` directly — all 11 block-decision scenarios ported (TDD-token, iterative-retrieval, session/handoff artifacts, loop confirmation), so coverage is preserved without the exit-2 wrapper mechanics.
- **Fixed CLAUDE.md** drift: the Rigid Skills section described the deleted per-skill `hooks/` dir + `hooks:` frontmatter; now documents the plugin-level observe-gate model.

Full suite green (26). No dangling `runAgentGuard`/`runStopAudit`/wrapper references.

---

*Created with Envoy*