### PR TITLE
Phase 3: opt-in strict enforcement (ENVOY_HOOK_PROFILE=strict) + logged override (closes #63)

### DIFF
--- a/.envoy-tasks/63.json
+++ b/.envoy-tasks/63.json
@@ -1,0 +1,54 @@
+{
+  "$schemaVersion": "1",
+  "strategy": "sequential",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "profile-aware enforcement",
+      "intent": "In strict mode the gate must actually block; in every other mode it stays observe-only. This is the enforce path, off by default.",
+      "behavior": [
+        "Given ENVOY_HOOK_PROFILE=strict and a would-block decision, when the gate runs, then it exits 2 (PreToolUse: reason on stderr) and records the block",
+        "Given no/other profile and a would-block, when the gate runs, then it logs and exits 0 (current observe behavior)",
+        "Given the gate logic throws, when it runs, then it exits 0 in ALL profiles (fail-open)"
+      ],
+      "files": [
+        "hooks/observe-gate.js",
+        "hooks/agent-guard.js",
+        "hooks/stop-audit.js",
+        "tests/hooks/strict-gate.test.js"
+      ],
+      "acceptance": [
+        "The gate returns a block signal only when ENVOY_HOOK_PROFILE==='strict' AND the decision blocks; agent-guard/stop-audit exit with that code (2 to block, else 0)",
+        "Non-strict is the prior observe behavior (log + exit 0), unchanged",
+        "Fail-open: a throw exits 0 even under strict",
+        "Contract test covers strict+block->exit2, non-strict+block->exit0+log, strict+throw->exit0"
+      ],
+      "outOfScope": [
+        "Making strict the DEFAULT profile (that stays gated on observe data)",
+        "Any non-gate code"
+      ]
+    },
+    {
+      "id": "task-2",
+      "title": "logged override escape hatch",
+      "intent": "A strict block must never be an unrecoverable dead end — the user can override, and the override is recorded so it shows in the compliance trail.",
+      "behavior": [
+        "Given ENVOY_HOOK_PROFILE=strict, a would-block, AND ENVOY_OVERRIDE set, when the gate runs, then it exits 0 (allows) and appends an override record ({kind:\"override\", ...}) to the log",
+        "Given a strict block WITHOUT override, when it blocks, then the stderr/message explains how to override"
+      ],
+      "files": [
+        "hooks/observe-gate.js",
+        "tests/hooks/strict-gate.test.js"
+      ],
+      "acceptance": [
+        "ENVOY_OVERRIDE converts a strict block into an allow (exit 0) with an override record logged",
+        "The block message names the override mechanism (ENVOY_OVERRIDE)",
+        "Full suite green under scripts/run-tests.js"
+      ],
+      "dependsOn": [
+        "task-1"
+      ]
+    }
+  ],
+  "issueNumber": 63
+}

--- a/hooks/agent-guard.js
+++ b/hooks/agent-guard.js
@@ -11,9 +11,10 @@ const { observe } = require('./observe-gate');
 /**
  * Entry point invoked by hook-runner with the raw stdin payload.
  * @param {string} data
+ * @returns {number} exit code from the gate (0 allow, 2 block under strict)
  */
 function run(data) {
-  observe('agent-guard', data);
+  return observe('agent-guard', data);
 }
 
 if (require.main === module) {
@@ -23,8 +24,13 @@ if (require.main === module) {
   } catch {
     input = '';
   }
-  run(input);
-  process.exit(0);
+  let code = 0;
+  try {
+    code = run(input);
+  } catch {
+    code = 0; // belt-and-suspenders: never block on gate failure
+  }
+  process.exit(code === 2 ? 2 : 0);
 }
 
 module.exports = { run };

--- a/hooks/hook-runner.js
+++ b/hooks/hook-runner.js
@@ -85,8 +85,8 @@ if (require.main === module) {
       process.stdin.setEncoding('utf8');
       process.stdin.on('data', (chunk) => { data += chunk; });
       process.stdin.on('end', () => {
-        hook.run(data);
-        process.exit(0);
+        const code = hook.run(data);
+        process.exit(typeof code === 'number' ? code : 0);
       });
     }
   } catch (err) {

--- a/hooks/observe-gate.js
+++ b/hooks/observe-gate.js
@@ -78,8 +78,11 @@ function observe(gate, data) {
 
     if (process.env.ENVOY_HOOK_PROFILE === 'strict') {
       // Escape hatch: a strict block is never an unrecoverable dead end.
-      // With ENVOY_OVERRIDE set, log the override and allow the call through.
-      if (process.env.ENVOY_OVERRIDE) {
+      // With ENVOY_OVERRIDE set (to anything but a falsy string), log the
+      // override and allow the call through. "0"/"false"/"" mean off, so a
+      // user who sets ENVOY_OVERRIDE=0 is not surprised by an enabled override.
+      const ov = (process.env.ENVOY_OVERRIDE || '').trim().toLowerCase();
+      if (ov !== '' && ov !== '0' && ov !== 'false') {
         appendObserveLog(cwd, { kind: 'override', ...record });
         return 0;
       }

--- a/hooks/observe-gate.js
+++ b/hooks/observe-gate.js
@@ -77,7 +77,15 @@ function observe(gate, data) {
     appendObserveLog(cwd, record);
 
     if (process.env.ENVOY_HOOK_PROFILE === 'strict') {
-      process.stderr.write(`Envoy ${gate} (strict) blocked: ${decision.reason}\n`);
+      // Escape hatch: a strict block is never an unrecoverable dead end.
+      // With ENVOY_OVERRIDE set, log the override and allow the call through.
+      if (process.env.ENVOY_OVERRIDE) {
+        appendObserveLog(cwd, { kind: 'override', ...record });
+        return 0;
+      }
+      process.stderr.write(
+        `Envoy ${gate} (strict) blocked: ${decision.reason}. To override: set ENVOY_OVERRIDE=1 and retry.\n`
+      );
       return 2;
     }
     return 0;

--- a/hooks/observe-gate.js
+++ b/hooks/observe-gate.js
@@ -4,12 +4,16 @@
  * ABOUTME: Plugin-level observe-mode gate core for agent-guard and stop-audit.
  * ABOUTME: Resolves the active skill's contract, logs would-block decisions, never blocks.
  *
- * OBSERVE MODE: these gates only watch. When the active rigid skill's contract
- * would block an Agent dispatch or a Stop, we append one JSON line to
- * .envoy/observe-log.jsonl and exit 0 anyway. Enforcement (exit 2) stays out of
- * this path entirely — we call the non-exiting evaluate* variants, never run*.
+ * OBSERVE MODE (default): these gates only watch. When the active rigid skill's
+ * contract would block an Agent dispatch or a Stop, we append one JSON line to
+ * .envoy/observe-log.jsonl and return 0 (allow) anyway.
  *
- * FAIL-OPEN: any error is swallowed. A broken gate must never block a tool call.
+ * STRICT MODE (ENVOY_HOOK_PROFILE=strict): the same would-block decision is
+ * ENFORCED — we still log it, write the reason to stderr, and return 2 (block)
+ * so the model sees why. Off by default; only the env var flips it.
+ *
+ * FAIL-OPEN: any error is swallowed and we return 0. A broken gate must never
+ * block a tool call — this holds even under strict.
  */
 
 const fs = require('fs');
@@ -31,16 +35,20 @@ function appendObserveLog(cwd, record) {
 }
 
 /**
- * Run one observe gate. Resolves the active skill (null → no-op), evaluates the
- * contract's would-block decision, and logs it. Always returns without throwing.
+ * Run one observe gate and return the exit code the runner should exit with.
+ * Resolves the active skill (null → 0), evaluates the contract's would-block
+ * decision, and logs it. Under ENVOY_HOOK_PROFILE=strict a would-block returns 2
+ * (and writes the reason to stderr); otherwise it returns 0 (observe only).
+ * Never throws — any error fails open to 0.
  * @param {'agent-guard'|'stop-audit'} gate
  * @param {string} data raw stdin payload (the tool-use / stop event JSON)
+ * @returns {number} exit code: 0 to allow, 2 to block (strict + would-block only)
  */
 function observe(gate, data) {
   try {
     const cwd = process.cwd();
     const active = readActiveSkill(cwd);
-    if (!active) return; // no rigid skill owns the session — nothing to guard
+    if (!active) return 0; // no rigid skill owns the session — nothing to guard
 
     const contractPath = path.join(PLUGIN_ROOT, 'skills', active.skill, 'contract.json');
 
@@ -50,14 +58,14 @@ function observe(gate, data) {
       try {
         event = JSON.parse(data || '{}');
       } catch {
-        return; // malformed event — fail open, nothing to observe
+        return 0; // malformed event — fail open, nothing to observe
       }
       decision = evaluateAgentGuard(contractPath, event);
     } else {
       decision = evaluateStopAudit(contractPath, cwd);
     }
 
-    if (!decision || !decision.block) return;
+    if (!decision || !decision.block) return 0;
 
     const record = {
       ts: new Date().toISOString(),
@@ -67,8 +75,15 @@ function observe(gate, data) {
     };
     if (decision.tool) record.tool = decision.tool;
     appendObserveLog(cwd, record);
+
+    if (process.env.ENVOY_HOOK_PROFILE === 'strict') {
+      process.stderr.write(`Envoy ${gate} (strict) blocked: ${decision.reason}\n`);
+      return 2;
+    }
+    return 0;
   } catch {
-    // fail-open: never block a tool call on gate failure
+    // fail-open: never block a tool call on gate failure, even under strict
+    return 0;
   }
 }
 

--- a/hooks/stop-audit.js
+++ b/hooks/stop-audit.js
@@ -11,9 +11,10 @@ const { observe } = require('./observe-gate');
 /**
  * Entry point invoked by hook-runner with the raw stdin payload.
  * @param {string} data
+ * @returns {number} exit code from the gate (0 allow, 2 block under strict)
  */
 function run(data) {
-  observe('stop-audit', data);
+  return observe('stop-audit', data);
 }
 
 if (require.main === module) {
@@ -23,8 +24,13 @@ if (require.main === module) {
   } catch {
     input = '';
   }
-  run(input);
-  process.exit(0);
+  let code = 0;
+  try {
+    code = run(input);
+  } catch {
+    code = 0; // belt-and-suspenders: never block on gate failure
+  }
+  process.exit(code === 2 ? 2 : 0);
 }
 
 module.exports = { run };

--- a/tests/hooks/strict-gate.test.js
+++ b/tests/hooks/strict-gate.test.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Strict-profile enforcement for the plugin observe-mode gates.
+ *
+ * The gates (agent-guard, stop-audit) stay observe-only by default: a would-block
+ * decision is logged and the gate exits 0. Under ENVOY_HOOK_PROFILE=strict the
+ * same would-block decision ENFORCES — the gate exits 2 with the reason on stderr
+ * (the PreToolUse/Stop block contract) while STILL logging. Fail-open is absolute:
+ * any thrown error in the gate path exits 0 even under strict.
+ *
+ * Run: node tests/hooks/strict-gate.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const AGENT_GUARD = path.join(REPO_ROOT, 'hooks', 'agent-guard.js');
+const STOP_AUDIT = path.join(REPO_ROOT, 'hooks', 'stop-audit.js');
+const OBSERVE_LOG = path.join('.envoy', 'observe-log.jsonl');
+
+const SESSION = 'strict-gate-test-session';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'strict-gate-'));
+}
+
+/** Write a fresh, non-stale active-skill marker for `skill` under `cwd`. */
+function writeMarker(cwd, skill) {
+  fs.mkdirSync(path.join(cwd, '.envoy'), { recursive: true });
+  fs.writeFileSync(
+    path.join(cwd, '.envoy', 'active-skill.json'),
+    JSON.stringify({
+      $schemaVersion: '1',
+      skill,
+      startedAt: new Date().toISOString(),
+      branch: 'unknown', // temp dir is not a git repo → currentBranch() === 'unknown'
+      session: SESSION,
+      pid: process.pid,
+    })
+  );
+}
+
+/** Spawn the gate script directly, merging `env` over a base that sets the session. */
+function runGate(gateScript, cwd, input, env = {}) {
+  return spawnSync('node', [gateScript], {
+    cwd,
+    encoding: 'utf8',
+    input: typeof input === 'string' ? input : JSON.stringify(input || {}),
+    env: { ...process.env, CLAUDE_SESSION_ID: SESSION, ...env },
+  });
+}
+
+function readLog(cwd) {
+  const p = path.join(cwd, OBSERVE_LOG);
+  if (!fs.existsSync(p)) return null;
+  return fs
+    .readFileSync(p, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+const blockingAgentEvent = {
+  tool_name: 'Agent',
+  tool_input: {
+    subagent_type: 'general-purpose',
+    description: 'Implement Task 1',
+    prompt: 'Implement Task 1: add feature\n\n(missing both Iron Law tokens)',
+  },
+};
+
+section('strict profile: would-block ENFORCES (exit 2 + stderr) and still logs');
+
+test('agent-guard strict + would-block → exit 2, reason on stderr, block logged', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 2, `expected exit 2, got ${r.status}\n${r.stderr}`);
+    assert.ok(r.stderr && r.stderr.trim().length > 0, 'block reason must be on stderr');
+    const log = readLog(tmp);
+    assert.ok(log && log.length === 1, 'block must still be logged under strict');
+    assert.strictEqual(log[0].gate, 'agent-guard');
+    assert.strictEqual(log[0].tool, 'Agent');
+    assert.ok(r.stderr.includes(log[0].reason), 'stderr should carry the logged reason');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('stop-audit strict + would-block → exit 2, reason on stderr, block logged', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup'); // pickup requires session.json + handoff which are absent
+    const r = runGate(STOP_AUDIT, tmp, {}, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 2, `expected exit 2, got ${r.status}\n${r.stderr}`);
+    assert.ok(r.stderr && r.stderr.trim().length > 0, 'block reason must be on stderr');
+    const log = readLog(tmp);
+    assert.ok(log && log.length === 1, 'block must still be logged under strict');
+    assert.strictEqual(log[0].gate, 'stop-audit');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+section('non-strict profile: would-block stays observe-only (exit 0 + log)');
+
+test('agent-guard unset profile + would-block → exit 0, block logged, no stderr', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent); // ENVOY_HOOK_PROFILE unset
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    assert.ok(!r.stderr || r.stderr.trim().length === 0, 'observe mode must not emit block stderr');
+    const log = readLog(tmp);
+    assert.ok(log && log.length === 1, 'observe mode still logs the would-block record');
+    assert.strictEqual(log[0].tool, 'Agent');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('agent-guard non-strict profile ("standard") + would-block → exit 0, logged', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent, { ENVOY_HOOK_PROFILE: 'standard' });
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    const log = readLog(tmp);
+    assert.ok(log && log.length === 1, 'standard profile still logs the would-block record');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+section('fail-open is absolute: a throwing gate exits 0 even under strict');
+
+test('agent-guard strict + append throws → exit 0 (fail-open beats enforcement)', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    // Make the observe-log path a directory so appendObserveLog throws EISDIR
+    // AFTER the block decision — the whole path must fail open to exit 0.
+    fs.mkdirSync(path.join(tmp, '.envoy', 'observe-log.jsonl'), { recursive: true });
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 0, `strict must still fail open on throw, got ${r.status}\n${r.stderr}`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+section('no active skill: exit 0, no log, all profiles');
+
+test('agent-guard strict + no active skill → exit 0 and no observe-log', () => {
+  const tmp = mkTmp();
+  try {
+    // no marker written
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    assert.strictEqual(readLog(tmp), null, 'no observe-log should exist when no skill is active');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('stop-audit strict + no active skill → exit 0 and no observe-log', () => {
+  const tmp = mkTmp();
+  try {
+    const r = runGate(STOP_AUDIT, tmp, {}, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    assert.strictEqual(readLog(tmp), null, 'no observe-log should exist when no skill is active');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+process.stdout.write(`\n\x1b[1m${passed} passed, ${failed} failed\x1b[0m\n`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/hooks/strict-gate.test.js
+++ b/tests/hooks/strict-gate.test.js
@@ -20,6 +20,7 @@ const { spawnSync } = require('child_process');
 const REPO_ROOT = path.join(__dirname, '..', '..');
 const AGENT_GUARD = path.join(REPO_ROOT, 'hooks', 'agent-guard.js');
 const STOP_AUDIT = path.join(REPO_ROOT, 'hooks', 'stop-audit.js');
+const HOOK_RUNNER = path.join(REPO_ROOT, 'hooks', 'hook-runner.js');
 const OBSERVE_LOG = path.join('.envoy', 'observe-log.jsonl');
 
 const SESSION = 'strict-gate-test-session';
@@ -65,6 +66,16 @@ function writeMarker(cwd, skill) {
 /** Spawn the gate script directly, merging `env` over a base that sets the session. */
 function runGate(gateScript, cwd, input, env = {}) {
   return spawnSync('node', [gateScript], {
+    cwd,
+    encoding: 'utf8',
+    input: typeof input === 'string' ? input : JSON.stringify(input || {}),
+    env: { ...process.env, CLAUDE_SESSION_ID: SESSION, ...env },
+  });
+}
+
+/** Spawn the hook through hook-runner (the real CLI dispatch path). */
+function runViaRunner(hookName, cwd, input, env = {}) {
+  return spawnSync('node', [HOOK_RUNNER, hookName], {
     cwd,
     encoding: 'utf8',
     input: typeof input === 'string' ? input : JSON.stringify(input || {}),
@@ -192,6 +203,107 @@ test('stop-audit strict + no active skill → exit 0 and no observe-log', () => 
     const r = runGate(STOP_AUDIT, tmp, {}, { ENVOY_HOOK_PROFILE: 'strict' });
     assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
     assert.strictEqual(readLog(tmp), null, 'no observe-log should exist when no skill is active');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+section('logged override escape hatch: ENVOY_OVERRIDE lets a strict block through');
+
+test('agent-guard strict + would-block + ENVOY_OVERRIDE=1 → exit 0, override logged', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent, {
+      ENVOY_HOOK_PROFILE: 'strict',
+      ENVOY_OVERRIDE: '1',
+    });
+    assert.strictEqual(r.status, 0, `override must allow, got ${r.status}\n${r.stderr}`);
+    const log = readLog(tmp);
+    assert.ok(log && log.length >= 1, 'override must be logged');
+    const override = log.find((rec) => rec.kind === 'override');
+    assert.ok(override, 'an override record must exist in the observe-log');
+    assert.strictEqual(override.gate, 'agent-guard');
+    assert.strictEqual(override.tool, 'Agent');
+    assert.strictEqual(override.skill, 'pickup');
+    assert.ok(override.reason && override.ts, 'override record carries reason + ts');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('agent-guard strict + would-block, no override → exit 2, stderr names ENVOY_OVERRIDE', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 2, `expected exit 2, got ${r.status}\n${r.stderr}`);
+    assert.ok(r.stderr.includes('ENVOY_OVERRIDE'), 'stderr must name the override mechanism');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+section('end-to-end through hook-runner: exit code propagates (the whole point)');
+
+test('hook-runner agent-guard strict + would-block → exit 2', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runViaRunner('agent-guard', tmp, blockingAgentEvent, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 2, `hook-runner must propagate exit 2, got ${r.status}\n${r.stderr}`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('hook-runner stop-audit strict + would-block → exit 2', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runViaRunner('stop-audit', tmp, {}, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 2, `hook-runner must propagate exit 2, got ${r.status}\n${r.stderr}`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('hook-runner agent-guard strict + would-block + ENVOY_OVERRIDE=1 → exit 0', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runViaRunner('agent-guard', tmp, blockingAgentEvent, {
+      ENVOY_HOOK_PROFILE: 'strict',
+      ENVOY_OVERRIDE: '1',
+    });
+    assert.strictEqual(r.status, 0, `override through hook-runner must allow, got ${r.status}\n${r.stderr}`);
+    const log = readLog(tmp);
+    assert.ok(log && log.some((rec) => rec.kind === 'override'), 'override logged through hook-runner');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('hook-runner backward compat: undefined-returning hook → exit 0', () => {
+  const tmp = mkTmp();
+  try {
+    // post-edit-accumulator.run() returns undefined for a non-Edit/Write event.
+    const r = runViaRunner('post-edit-accumulator', tmp, { tool_name: 'Read', tool_input: {} }, {
+      ENVOY_HOOK_PROFILE: 'strict',
+    });
+    assert.strictEqual(r.status, 0, `undefined-return hook must exit 0, got ${r.status}\n${r.stderr}`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('hook-runner fail-open: throwing gate path → exit 0 even under strict', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    fs.mkdirSync(path.join(tmp, '.envoy', 'observe-log.jsonl'), { recursive: true });
+    const r = runViaRunner('agent-guard', tmp, blockingAgentEvent, { ENVOY_HOOK_PROFILE: 'strict' });
+    assert.strictEqual(r.status, 0, `hook-runner must fail open on throw, got ${r.status}\n${r.stderr}`);
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/tests/hooks/strict-gate.test.js
+++ b/tests/hooks/strict-gate.test.js
@@ -244,6 +244,17 @@ test('agent-guard strict + would-block, no override → exit 2, stderr names ENV
   }
 });
 
+test('ENVOY_OVERRIDE=0 does NOT override (still blocks under strict)', () => {
+  const tmp = mkTmp();
+  try {
+    writeMarker(tmp, 'pickup');
+    const r = runGate(AGENT_GUARD, tmp, blockingAgentEvent, { ENVOY_HOOK_PROFILE: 'strict', ENVOY_OVERRIDE: '0' });
+    assert.strictEqual(r.status, 2, `ENVOY_OVERRIDE=0 must not enable override; expected exit 2, got ${r.status}`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 section('end-to-end through hook-runner: exit code propagates (the whole point)');
 
 test('hook-runner agent-guard strict + would-block → exit 2', () => {


### PR DESCRIPTION
Makes the plugin gates actually **enforce** — opt-in via `ENVOY_HOOK_PROFILE=strict`, with a logged override so a false positive is never a dead end. Default stays observe-only; arming strict *as the default* remains gated on observe-log data. **Closes #63.**

## Changes
- `hooks/observe-gate.js`: under `strict` a would-block returns exit 2 (reason on stderr) + logs it; non-strict is unchanged observe (log + exit 0). `ENVOY_OVERRIDE` (truthy, not `0`/`false`/empty) turns a strict block into an allow with a logged `{kind:"override"}` record; the block message names the override.
- `hooks/hook-runner.js`: now propagates a numeric return code (`exit(typeof code===number?code:0)`) instead of always 0 — **this was swallowing the exit 2**, so enforcement was inert end-to-end. Backward-compatible (every other hook returns undefined -> 0; config-protection exits internally).
- `hooks/agent-guard.js`/`stop-audit.js`: exit with the gate code.

## Safety (heavily reviewed — this can now block a tool)
- **Fail-open airtight under strict:** every throw path (contract read, marker, log append, evaluate, stderr) falls to `return 0`; the `return 2` is only on the fully-successful path. Verified with a forced-throw (EISDIR) test, directly and through hook-runner.
- **hook-runner backward-compat verified:** no other dispatched hook returns a number.
- Real spawn-through-hook-runner tests prove exit 2 / override / fail-open end-to-end.

## After merge (dogfood)
Enable `ENVOY_HOOK_PROFILE=strict` for envoy-repo work, run real pickups, and review `.envoy/observe-log.jsonl` for false positives before proposing strict-as-default.

---

*Created with Envoy*