### PR TITLE
Phase 3: durable ledger (.envoy/ledger.jsonl) + PreCompact snapshot + SessionStart tail injection (closes #65)

### DIFF
--- a/.envoy-tasks/65.json
+++ b/.envoy-tasks/65.json
@@ -1,0 +1,55 @@
+{
+  "$schemaVersion": "1",
+  "strategy": "sequential",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "ledger primitive + lifecycle events",
+      "intent": "A durable, size-capped diary of workflow events so context loss doesn't erase what happened.",
+      "behavior": [
+        "Given appendEvent(dir, {type}), when it runs, then one JSON line stamped with ts + branch + issue is appended to dir/.envoy/ledger.jsonl",
+        "Given more than the cap of lines, when appendEvent runs, then the file is trimmed to the last N lines (oldest dropped)",
+        "Given tailLedger(dir, n), then it returns the last n parsed events (or fewer); a missing or corrupt file yields an empty array and does not throw"
+      ],
+      "files": [
+        "lib/ledger.js",
+        "tests/lib/ledger.test.js",
+        "skills/pickup/preflight.js",
+        "skills/pickup/steps/handoff.md"
+      ],
+      "acceptance": [
+        "lib/ledger.js exports appendEvent(dir, event), readLedger(dir), tailLedger(dir, n) with ts+branch+issue tagging and a line cap; robust to missing/corrupt file (no throw)",
+        "pickup preflight appends a skill-started event; a handoff-written event is appended when a handoff JSON is written",
+        "Zero-dependency Node; hermetic unit tests (temp dirs, injectable branch/issue/now)"
+      ],
+      "outOfScope": [
+        "Subsuming observe-log.jsonl (kept separate per decision)",
+        "Gate events (stay in observe-log)"
+      ]
+    },
+    {
+      "id": "task-2",
+      "title": "PreCompact snapshot + SessionStart tail injection",
+      "intent": "Capture state before context trims and re-inject it on wake-up, so the assistant trusts the record over fuzzy memory.",
+      "behavior": [
+        "Given the context is about to compact, when the PreCompact hook fires, then a pre-compact snapshot event is appended to the ledger (fail-open: never breaks compaction)",
+        "Given a session starts (startup/resume/compact), when SessionStart runs, then the injected additionalContext includes the ledger tail + a recent git-log summary, framed to trust them over recollection"
+      ],
+      "files": [
+        "hooks/hooks.json",
+        "hooks/pre-compact.js",
+        "hooks/session-start.sh",
+        "tests/hooks/ledger-hooks.test.js"
+      ],
+      "acceptance": [
+        "PreCompact is registered in hooks.json; the hook appends a pre-compact event and is fail-open (never breaks compaction)",
+        "SessionStart output's additionalContext includes the ledger tail + recent git log with the trust-the-record framing",
+        "Contract/behaviour test proves the PreCompact append and the SessionStart injection; full suite green under scripts/run-tests.js"
+      ],
+      "dependsOn": [
+        "task-1"
+      ]
+    }
+  ],
+  "issueNumber": 65
+}

--- a/hooks/hook-runner.js
+++ b/hooks/hook-runner.js
@@ -23,6 +23,7 @@ const path = require('path');
 const HOOK_PROFILES = {
   'session-start':          ['minimal', 'standard', 'strict'],
   'config-protection':      ['minimal', 'standard', 'strict'],
+  'pre-compact':            ['minimal', 'standard', 'strict'],
   'post-edit-accumulator':  ['standard', 'strict'],
   'stop-batch-lint':        ['standard', 'strict'],
   'learning-extractor':     ['standard', 'strict'],

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -68,6 +68,18 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.js\" pre-compact",
+            "_profiles": ["minimal", "standard", "strict"]
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/hooks/pre-compact.js
+++ b/hooks/pre-compact.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * ABOUTME: PreCompact hook — records a pre-compact event in the durable ledger.
+ * ABOUTME: Fail-open: any error is swallowed and it always exits 0, never blocking compaction.
+ */
+
+const path = require('path');
+
+/**
+ * Append a pre-compact event to the ledger. Never throws.
+ * @param {string} [_rawInput] - PreCompact stdin payload (unused).
+ * @returns {number} Always 0.
+ */
+function run(_rawInput) {
+  try {
+    const { appendEvent } = require(path.join(__dirname, '..', 'lib', 'ledger'));
+    appendEvent(process.cwd(), { type: 'pre-compact' });
+  } catch (_err) {
+    // Fail-open: a PreCompact hook must never break compaction.
+  }
+  return 0;
+}
+
+// CLI mode
+if (require.main === module) {
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { data += chunk; });
+  process.stdin.on('end', () => {
+    run(data);
+    process.exit(0);
+  });
+}
+
+module.exports = { run };

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -125,6 +125,42 @@ Load full state with: \`const session = require('./lib/session-state').load()\`
 To clear after branch is done: \`require('./lib/session-state').clear()\`"
 fi
 
+# Recent workflow record from the durable ledger (trust the record over recollection)
+WORKFLOW_RECORD=""
+if [ -f ".envoy/ledger.jsonl" ]; then
+    LEDGER_TAIL=$(node -e '
+      try {
+        const { tailLedger } = require(process.argv[1]);
+        const events = tailLedger(process.cwd(), 10);
+        const lines = events.map((e) => {
+          const parts = [e.ts, e.branch, e.type || e.event || "event"];
+          if (e.issue !== undefined && e.issue !== null) parts.push("#" + e.issue);
+          if (e.skill) parts.push(e.skill);
+          if (e.detail) parts.push(e.detail);
+          return "- " + parts.filter(Boolean).join(" ");
+        });
+        process.stdout.write(lines.join("\n"));
+      } catch (_err) {}
+    ' "$PLUGIN_DIR/lib/ledger" 2>/dev/null)
+
+    if [ -n "$LEDGER_TAIL" ]; then
+        WORKFLOW_RECORD="---
+
+**Recent workflow record (trust this + git log over recollection)**
+
+Ledger (last events):
+$LEDGER_TAIL"
+
+        GIT_LOG=$(git log --oneline -10 2>/dev/null)
+        if [ -n "$GIT_LOG" ]; then
+            WORKFLOW_RECORD="$WORKFLOW_RECORD
+
+Recent git log:
+$GIT_LOG"
+        fi
+    fi
+fi
+
 # Build stack list for output
 if [ -n "$DETECTED_STACKS" ]; then
     STACK_INFO="**Detected stacks:** $DETECTED_STACKS
@@ -146,6 +182,7 @@ $SKILL_CONTENT
 
 $STACK_INFO
 $SESSION_STATE
+$WORKFLOW_RECORD
 </EXTREMELY_IMPORTANT>"
 
 # Escape for JSON

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -1,0 +1,148 @@
+'use strict';
+
+/**
+ * Durable append-only workflow ledger.
+ *
+ * The ledger lives at .envoy/ledger.jsonl and records one JSON line per
+ * lifecycle event (skill started, handoff written, …). It is the workflow's
+ * diary: a flat, greppable trail of what happened, in order, across a run.
+ *
+ * Every event is stamped with `ts` (ISO time), `branch` (the git branch it was
+ * written under), and optionally `issue` (the issue number in play). The file
+ * is size-capped so an unbounded run never grows it without limit — once it
+ * exceeds `maxLines`, the oldest lines are dropped.
+ *
+ * A diary write must never break the workflow it observes, so appendEvent is
+ * fail-soft: any fs error is swallowed. Reads are equally forgiving — a missing
+ * file yields [] and corrupt lines are skipped rather than thrown on.
+ *
+ * Zero external dependencies. `now`, `branch`, `issue`, and `maxLines` are
+ * injectable so callers can test hermetically without touching the real repo's
+ * git state or clock.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const LEDGER_REL = path.join('.envoy', 'ledger.jsonl');
+
+/** Default size cap: keep the last 500 events. */
+const DEFAULT_MAX_LINES = 500;
+
+/**
+ * Resolve the ledger path under a working directory.
+ * @param {string} dir
+ * @returns {string}
+ */
+function ledgerPath(dir) {
+  return path.join(dir, LEDGER_REL);
+}
+
+/**
+ * Current git branch for a directory, or 'unknown' when git is unavailable.
+ * @param {string} dir
+ * @returns {string}
+ */
+function currentBranch(dir) {
+  try {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch (_err) {
+    return 'unknown';
+  }
+}
+
+/**
+ * Append one stamped event to dir/.envoy/ledger.jsonl. Creates .envoy when
+ * missing and trims the file to the last `maxLines` events after appending.
+ * Never throws — any fs error is swallowed so a diary write cannot break a
+ * workflow.
+ * @param {string} dir - Working directory root (ledger written under dir/.envoy).
+ * @param {object} event - Event fields; merged over the stamped fields.
+ * @param {{now?: Date, branch?: string, issue?: number, maxLines?: number}} [opts]
+ */
+function appendEvent(dir, event = {}, opts = {}) {
+  try {
+    const now = opts.now || new Date();
+    const branch = opts.branch !== undefined ? opts.branch : currentBranch(dir);
+    const issue = event.issue !== undefined ? event.issue : opts.issue;
+    const maxLines = opts.maxLines !== undefined ? opts.maxLines : DEFAULT_MAX_LINES;
+
+    const record = {
+      ts: now.toISOString(),
+      branch,
+    };
+    if (issue !== undefined && issue !== null) record.issue = issue;
+    Object.assign(record, event);
+
+    const full = ledgerPath(dir);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.appendFileSync(full, `${JSON.stringify(record)}\n`);
+
+    trimToMaxLines(full, maxLines);
+  } catch (_err) {
+    // Fail-soft: a diary write must never break the workflow it observes.
+  }
+}
+
+/**
+ * Trim a ledger file to its last `maxLines` lines, dropping the oldest. No-op
+ * when the file is already within the cap or maxLines is not positive.
+ * @param {string} full
+ * @param {number} maxLines
+ */
+function trimToMaxLines(full, maxLines) {
+  if (!(maxLines > 0)) return;
+  const lines = fs.readFileSync(full, 'utf8').split('\n').filter((l) => l.length > 0);
+  if (lines.length <= maxLines) return;
+  const kept = lines.slice(lines.length - maxLines);
+  fs.writeFileSync(full, `${kept.join('\n')}\n`);
+}
+
+/**
+ * Read all events from the ledger. Missing file → []; corrupt lines are skipped
+ * rather than thrown on.
+ * @param {string} dir
+ * @returns {object[]}
+ */
+function readLedger(dir) {
+  let raw;
+  try {
+    raw = fs.readFileSync(ledgerPath(dir), 'utf8');
+  } catch (_err) {
+    return [];
+  }
+  const events = [];
+  for (const line of raw.split('\n')) {
+    if (line.length === 0) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch (_err) {
+      // Skip a corrupt line — the diary stays readable.
+    }
+  }
+  return events;
+}
+
+/**
+ * Read the last `n` events from the ledger (or fewer). Missing file → [].
+ * @param {string} dir
+ * @param {number} n
+ * @returns {object[]}
+ */
+function tailLedger(dir, n) {
+  const events = readLedger(dir);
+  if (!(n > 0)) return [];
+  return events.slice(Math.max(0, events.length - n));
+}
+
+module.exports = {
+  appendEvent,
+  readLedger,
+  tailLedger,
+  DEFAULT_MAX_LINES,
+};

--- a/skills/pickup/preflight.js
+++ b/skills/pickup/preflight.js
@@ -22,6 +22,7 @@ const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '
 const { validateFile } = require(path.join(REPO_ROOT, 'lib', 'validate-schema'));
 const { extractEmbeddedBlock } = require(path.join(REPO_ROOT, 'lib', 'tasks-embed'));
 const { writeActiveSkill } = require(path.join(REPO_ROOT, 'lib', 'active-skill'));
+const { appendEvent } = require(path.join(REPO_ROOT, 'lib', 'ledger'));
 
 // Best-effort fetch of an issue body via gh. Returns the body string, or null
 // when gh is unavailable or the call fails — callers must tolerate null.
@@ -142,6 +143,7 @@ function main() {
   };
   writeJson('.envoy/pickup/session.json', session);
   writeActiveSkill(CWD, { skill: 'pickup', issueNumber: issueNumber ? Number(issueNumber) : undefined });
+  appendEvent(CWD, { type: 'skill-started', skill: 'pickup', issue: Number(issueNumber) });
 
   const tier = strictPromote(materialized ? 'degraded' : 'ok');
   banner(tier);

--- a/skills/pickup/steps/verify.md
+++ b/skills/pickup/steps/verify.md
@@ -36,6 +36,8 @@ const handoff = {
 
 fs.mkdirSync('.envoy/pickup', { recursive: true });
 fs.writeFileSync('.envoy/pickup/handoff-to-review.json', JSON.stringify(handoff, null, 2));
+
+require('../../lib/ledger').appendEvent(process.cwd(), { type: 'handoff-written', from: 'pickup', to: 'review' });
 ```
 
 Review preflight will read this file and fail fatal if it's missing, so skipping this write blocks the pipeline.

--- a/tests/hooks/ledger-hooks.test.js
+++ b/tests/hooks/ledger-hooks.test.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * ABOUTME: Tests the PreCompact ledger hook and SessionStart tail injection.
+ * ABOUTME: pre-compact appends a diary event (fail-open); session-start injects the tail.
+ *
+ * Run: node tests/hooks/ledger-hooks.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync, execFileSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const HOOKS_JSON = path.join(REPO_ROOT, 'hooks', 'hooks.json');
+const PRE_COMPACT = path.join(REPO_ROOT, 'hooks', 'pre-compact.js');
+const HOOK_RUNNER = path.join(REPO_ROOT, 'hooks', 'hook-runner.js');
+const SESSION_START = path.join(REPO_ROOT, 'hooks', 'session-start.sh');
+const { appendEvent, readLedger } = require(path.join(REPO_ROOT, 'lib', 'ledger'));
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ledger-hooks-'));
+}
+
+function runPreCompact(cwd, script) {
+  return spawnSync('node', [script], {
+    cwd,
+    encoding: 'utf8',
+    input: JSON.stringify({ hook_event_name: 'PreCompact', trigger: 'auto', cwd }),
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: REPO_ROOT },
+  });
+}
+
+function runSessionStart(cwd) {
+  return execFileSync('bash', [SESSION_START], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 30000,
+    input: JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup', session_id: 'test', cwd }),
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: REPO_ROOT },
+  });
+}
+
+section('registration: PreCompact wired in hooks/hooks.json');
+
+const hooksConfig = JSON.parse(fs.readFileSync(HOOKS_JSON, 'utf8'));
+
+test('PreCompact registers pre-compact via hook-runner', () => {
+  const pre = hooksConfig.hooks.PreCompact || [];
+  assert.ok(pre.length > 0, 'no PreCompact entries in hooks.json');
+  const cmd = pre.flatMap((e) => e.hooks.map((h) => h.command)).join(' ');
+  assert.ok(/hook-runner\.js" pre-compact/.test(cmd), `pre-compact not wired via hook-runner: ${cmd}`);
+});
+
+section('pre-compact appends a diary event');
+
+test('running pre-compact appends a pre-compact event', () => {
+  const tmp = mkTmp();
+  try {
+    const r = runPreCompact(tmp, PRE_COMPACT);
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+    const events = readLedger(tmp);
+    assert.ok(events.length >= 1, 'expected at least one ledger event');
+    assert.ok(events.some((e) => e.type === 'pre-compact'), 'no pre-compact event appended');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('hook-runner dispatches pre-compact', () => {
+  const tmp = mkTmp();
+  try {
+    const r2 = spawnSync('node', [HOOK_RUNNER, 'pre-compact'], {
+      cwd: tmp,
+      encoding: 'utf8',
+      input: JSON.stringify({ hook_event_name: 'PreCompact', trigger: 'auto', cwd: tmp }),
+      env: { ...process.env, CLAUDE_PLUGIN_ROOT: REPO_ROOT },
+    });
+    assert.strictEqual(r2.status, 0, `expected exit 0, got ${r2.status}\n${r2.stderr}`);
+    const events = readLedger(tmp);
+    assert.ok(events.some((e) => e.type === 'pre-compact'), 'hook-runner did not dispatch pre-compact');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pre-compact is fail-open when the ledger dir is unwritable', () => {
+  const tmp = mkTmp();
+  try {
+    // Make .envoy a regular file so mkdir/append fails inside appendEvent.
+    fs.writeFileSync(path.join(tmp, '.envoy'), 'not a directory');
+    const r = runPreCompact(tmp, PRE_COMPACT);
+    assert.strictEqual(r.status, 0, `PreCompact must never break compaction; got ${r.status}\n${r.stderr}`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+section('session-start injects the ledger tail with framing');
+
+test('seeded ledger → additionalContext carries the tail + framing', () => {
+  const tmp = mkTmp();
+  try {
+    appendEvent(tmp, { type: 'skill-started', skill: 'pickup-marker-abc' });
+    const parsed = JSON.parse(runSessionStart(tmp));
+    const ctx = parsed.hookSpecificOutput.additionalContext;
+    assert.strictEqual(typeof ctx, 'string');
+    assert.ok(/Recent workflow record/.test(ctx), 'framing header missing');
+    assert.ok(/trust/i.test(ctx), 'trust-the-record framing missing');
+    assert.ok(ctx.includes('pickup-marker-abc'), 'seeded tail event missing from context');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('no ledger → output is still valid JSON and unchanged (no framing)', () => {
+  const tmp = mkTmp();
+  try {
+    const raw = runSessionStart(tmp);
+    const parsed = JSON.parse(raw);
+    assert.strictEqual(parsed.hookSpecificOutput.hookEventName, 'SessionStart');
+    const ctx = parsed.hookSpecificOutput.additionalContext;
+    assert.ok(!/Recent workflow record/.test(ctx), 'framing must be absent when no ledger exists');
+    assert.ok(ctx.includes('EXTREMELY_IMPORTANT'), 'bootstrap wrapper must still be present');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+process.stdout.write(`\n\x1b[1m${passed} passed, ${failed} failed\x1b[0m\n`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/lib/ledger.test.js
+++ b/tests/lib/ledger.test.js
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * Durable append-only workflow ledger — Test Suite
+ *
+ * Run: node tests/lib/ledger.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const LIB = path.join(__dirname, '..', '..', 'lib');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function ledgerPath(dir) {
+  return path.join(dir, '.envoy', 'ledger.jsonl');
+}
+
+function readLines(dir) {
+  return fs
+    .readFileSync(ledgerPath(dir), 'utf8')
+    .split('\n')
+    .filter((l) => l.length > 0);
+}
+
+const ledger = require(path.join(LIB, 'ledger'));
+
+// ═══════════════════════════════════════════════════════════════════
+// Exports
+// ═══════════════════════════════════════════════════════════════════
+
+section('exports');
+
+test('appendEvent is exported', () => {
+  assert.strictEqual(typeof ledger.appendEvent, 'function');
+});
+
+test('readLedger is exported', () => {
+  assert.strictEqual(typeof ledger.readLedger, 'function');
+});
+
+test('tailLedger is exported', () => {
+  assert.strictEqual(typeof ledger.tailLedger, 'function');
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// appendEvent — stamping + file creation
+// ═══════════════════════════════════════════════════════════════════
+
+section('appendEvent: stamps ts + branch + issue; creates .envoy');
+
+test('creates .envoy directory and writes one JSON line', () => {
+  const dir = makeTmp('ledger-append-');
+  assert.ok(!fs.existsSync(path.join(dir, '.envoy')));
+  ledger.appendEvent(dir, { type: 'skill-started', skill: 'pickup' }, {
+    now: new Date('2026-07-21T10:00:00.000Z'),
+    branch: 'feature/65-ledger',
+  });
+  assert.ok(fs.existsSync(ledgerPath(dir)));
+  assert.strictEqual(readLines(dir).length, 1);
+  cleanup(dir);
+});
+
+test('stamps ts and branch and merges event fields', () => {
+  const dir = makeTmp('ledger-append-');
+  ledger.appendEvent(dir, { type: 'skill-started', skill: 'pickup' }, {
+    now: new Date('2026-07-21T10:00:00.000Z'),
+    branch: 'feature/65-ledger',
+  });
+  const ev = JSON.parse(readLines(dir)[0]);
+  assert.strictEqual(ev.ts, '2026-07-21T10:00:00.000Z');
+  assert.strictEqual(ev.branch, 'feature/65-ledger');
+  assert.strictEqual(ev.type, 'skill-started');
+  assert.strictEqual(ev.skill, 'pickup');
+  cleanup(dir);
+});
+
+test('stamps issue from event.issue', () => {
+  const dir = makeTmp('ledger-append-');
+  ledger.appendEvent(dir, { type: 'skill-started', issue: 65 }, {
+    now: new Date(), branch: 'b',
+  });
+  const ev = JSON.parse(readLines(dir)[0]);
+  assert.strictEqual(ev.issue, 65);
+  cleanup(dir);
+});
+
+test('stamps issue from opts.issue when event has none', () => {
+  const dir = makeTmp('ledger-append-');
+  ledger.appendEvent(dir, { type: 'skill-started' }, {
+    now: new Date(), branch: 'b', issue: 42,
+  });
+  const ev = JSON.parse(readLines(dir)[0]);
+  assert.strictEqual(ev.issue, 42);
+  cleanup(dir);
+});
+
+test('omits issue when neither event nor opts provide it', () => {
+  const dir = makeTmp('ledger-append-');
+  ledger.appendEvent(dir, { type: 'skill-started' }, {
+    now: new Date(), branch: 'b',
+  });
+  const ev = JSON.parse(readLines(dir)[0]);
+  assert.ok(!('issue' in ev), 'issue should be omitted');
+  cleanup(dir);
+});
+
+test('appends successive events as separate lines', () => {
+  const dir = makeTmp('ledger-append-');
+  const opts = { now: new Date(), branch: 'b' };
+  ledger.appendEvent(dir, { type: 'a' }, opts);
+  ledger.appendEvent(dir, { type: 'b' }, opts);
+  ledger.appendEvent(dir, { type: 'c' }, opts);
+  const lines = readLines(dir);
+  assert.strictEqual(lines.length, 3);
+  assert.strictEqual(JSON.parse(lines[0]).type, 'a');
+  assert.strictEqual(JSON.parse(lines[2]).type, 'c');
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// appendEvent — size cap
+// ═══════════════════════════════════════════════════════════════════
+
+section('appendEvent: size-capped, oldest dropped');
+
+test('trims to maxLines, dropping oldest', () => {
+  const dir = makeTmp('ledger-cap-');
+  const opts = { now: new Date(), branch: 'b', maxLines: 3 };
+  for (let i = 0; i < 6; i++) ledger.appendEvent(dir, { type: 'e', n: i }, opts);
+  const lines = readLines(dir);
+  assert.strictEqual(lines.length, 3);
+  assert.strictEqual(JSON.parse(lines[0]).n, 3);
+  assert.strictEqual(JSON.parse(lines[2]).n, 5);
+  cleanup(dir);
+});
+
+test('does not trim while under the cap', () => {
+  const dir = makeTmp('ledger-cap-');
+  const opts = { now: new Date(), branch: 'b', maxLines: 10 };
+  for (let i = 0; i < 4; i++) ledger.appendEvent(dir, { type: 'e', n: i }, opts);
+  assert.strictEqual(readLines(dir).length, 4);
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// appendEvent — fail-soft
+// ═══════════════════════════════════════════════════════════════════
+
+section('appendEvent: never throws on fs error');
+
+test('does not throw when dir is unwritable (fs error swallowed)', () => {
+  // A file where the .envoy directory should be forces mkdir/append to fail.
+  const dir = makeTmp('ledger-failsoft-');
+  fs.writeFileSync(path.join(dir, '.envoy'), 'not a directory', 'utf8');
+  assert.doesNotThrow(() => {
+    ledger.appendEvent(dir, { type: 'x' }, { now: new Date(), branch: 'b' });
+  });
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// readLedger
+// ═══════════════════════════════════════════════════════════════════
+
+section('readLedger: parse all; missing ⇒ []; corrupt line skipped');
+
+test('returns all parsed events', () => {
+  const dir = makeTmp('ledger-read-');
+  const opts = { now: new Date(), branch: 'b' };
+  ledger.appendEvent(dir, { type: 'a' }, opts);
+  ledger.appendEvent(dir, { type: 'b' }, opts);
+  const events = ledger.readLedger(dir);
+  assert.strictEqual(events.length, 2);
+  assert.strictEqual(events[0].type, 'a');
+  assert.strictEqual(events[1].type, 'b');
+  cleanup(dir);
+});
+
+test('missing file returns []', () => {
+  const dir = makeTmp('ledger-read-');
+  assert.deepStrictEqual(ledger.readLedger(dir), []);
+  cleanup(dir);
+});
+
+test('skips corrupt lines without throwing', () => {
+  const dir = makeTmp('ledger-read-');
+  fs.mkdirSync(path.join(dir, '.envoy'), { recursive: true });
+  fs.writeFileSync(
+    ledgerPath(dir),
+    `${JSON.stringify({ type: 'a' })}\n{ not json\n${JSON.stringify({ type: 'b' })}\n`,
+    'utf8'
+  );
+  let events;
+  assert.doesNotThrow(() => {
+    events = ledger.readLedger(dir);
+  });
+  assert.strictEqual(events.length, 2);
+  assert.strictEqual(events[0].type, 'a');
+  assert.strictEqual(events[1].type, 'b');
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// tailLedger
+// ═══════════════════════════════════════════════════════════════════
+
+section('tailLedger: last n events; missing ⇒ []');
+
+test('returns the last n events', () => {
+  const dir = makeTmp('ledger-tail-');
+  const opts = { now: new Date(), branch: 'b' };
+  for (let i = 0; i < 5; i++) ledger.appendEvent(dir, { type: 'e', n: i }, opts);
+  const tail = ledger.tailLedger(dir, 2);
+  assert.strictEqual(tail.length, 2);
+  assert.strictEqual(tail[0].n, 3);
+  assert.strictEqual(tail[1].n, 4);
+  cleanup(dir);
+});
+
+test('returns fewer when n exceeds count', () => {
+  const dir = makeTmp('ledger-tail-');
+  ledger.appendEvent(dir, { type: 'e', n: 0 }, { now: new Date(), branch: 'b' });
+  const tail = ledger.tailLedger(dir, 10);
+  assert.strictEqual(tail.length, 1);
+  cleanup(dir);
+});
+
+test('missing file returns []', () => {
+  const dir = makeTmp('ledger-tail-');
+  assert.deepStrictEqual(ledger.tailLedger(dir, 3), []);
+  cleanup(dir);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Summary
+// ═══════════════════════════════════════════════════════════════════
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
A durable **workflow diary** so a session that loses context (compaction/resume/new session) knows what actually happened instead of guessing. **Closes #65.**

## Changes
- **`lib/ledger.js`** (zero-dep, fail-soft): `appendEvent`/`readLedger`/`tailLedger` for `.envoy/ledger.jsonl` — each event stamped ts+branch+issue, **size-capped** (last 500 lines), robust to missing/corrupt files. A diary write can never break a workflow.
- **Lifecycle events:** pickup preflight emits `skill-started`; the review-handoff step emits `handoff-written`.
- **PreCompact hook** (`hooks/pre-compact.js`, registered in `hooks.json`): appends a `pre-compact` snapshot before context trims; fail-open (never breaks compaction).
- **SessionStart injection** (`hooks/session-start.sh`): injects the ledger tail + recent `git log` into context, framed *trust this + git log over recollection*.

## Decision
The ledger **complements** the observe-log (gate events stay there for arming analysis; the ledger records workflow lifecycle) — not subsumed, to avoid churning #64. Also produces the compliance trail Phase 6 reads.

## Safety (reviewed)
- Ledger writes fail-soft; PreCompact fail-open (two layers).
- **#31 SessionStart JSON shape preserved** — ledger content goes through the same `escape_json`; verified well-formed with adversarial content (quotes/backslashes/newlines).
- Real-hook end-to-end tests (session-start.sh + pre-compact via child_process).

## Test Plan
- [x] `node scripts/run-tests.js` — 29 files green (new: `ledger.test.js` 18, `ledger-hooks.test.js` 6)
- [x] SessionStart output still `JSON.parse`-able with a seeded multi-event ledger

## Linked Issue
Closes #65

---

*Created with Envoy*