### PR TITLE
Phase 6: lib/compliance.js — per-PR skill-compliance trail (closes #41)

### DIFF
--- a/.envoy-tasks/41.json
+++ b/.envoy-tasks/41.json
@@ -1,0 +1,56 @@
+{
+  "$schemaVersion": "1",
+  "strategy": "sequential",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "complete lifecycle-event emission across rigid skills",
+      "intent": "The ledger only records skill-started from pickup (the #65 representative). For a meaningful pickup->review->finalize trail, every rigid skill must emit it.",
+      "behavior": [
+        "Given each rigid skill's preflight runs, when it runs, then it appends a skill-started event (with the skill name + issue when known) to .envoy/ledger.jsonl",
+        "Given the review->finalize handoff is written, when it is written, then a handoff-written event is appended (from:review, to:finalize)"
+      ],
+      "files": [
+        "skills/review/preflight.js",
+        "skills/finalize/preflight.js",
+        "skills/cleanup/preflight.js",
+        "skills/fix-ci/preflight.js",
+        "skills/wiki-sync/preflight.js",
+        "skills/coderabbit-pr-review/preflight.js",
+        "skills/review/SKILL.md",
+        "tests/lib/lifecycle-events.test.js"
+      ],
+      "acceptance": [
+        "review/finalize/cleanup/fix-ci/wiki-sync/coderabbit-pr-review preflights append a skill-started event (fail-soft, mirroring pickup's wiring)",
+        "The review->finalize handoff write also appends handoff-written (from:review, to:finalize)",
+        "A test drives each wired preflight and asserts a skill-started event lands in the ledger (hermetic temp dirs)"
+      ],
+      "outOfScope": [
+        "hotfix (has its own active-skill write; wire only if trivially consistent)",
+        "brainstorm (flexible skill, no preflight — its evidence is the committed .envoy-tasks file)"
+      ]
+    },
+    {
+      "id": "task-2",
+      "title": "lib/compliance.js — per-PR skill-compliance trail",
+      "intent": "Given a branch, show whether the work flowed through the rigid workflow or skipped steps, plus gate overrides — the instrument that measures whether strict would false-positive.",
+      "behavior": [
+        "Given a branch with ledger + observe-log events, when node lib/compliance.js <branch> runs, then it prints a per-PR trail: which rigid steps (pickup/review/finalize/cleanup) ran vs skipped, the gate-override count, and hotfix flagged as sanctioned",
+        "Given no events for the branch, when it runs, then it reports nothing-recorded cleanly (no throw)"
+      ],
+      "files": [
+        "lib/compliance.js",
+        "tests/lib/compliance.test.js"
+      ],
+      "acceptance": [
+        "node lib/compliance.js <branch> reads .envoy/ledger.jsonl (skill-started, handoff-written) AND .envoy/observe-log.jsonl (gate blocks/overrides), filtered to the branch",
+        "Renders a prose trail: steps ran/skipped, gate-override count, hotfix distinguished as a sanctioned fast-path (not skill-less work)",
+        "Pure/testable core (parse+render separated from fs/CLI); zero-dep; hermetic unit tests with fixture ledger/observe-log; missing files -> clean empty report"
+      ],
+      "dependsOn": [
+        "task-1"
+      ]
+    }
+  ],
+  "issueNumber": 41
+}

--- a/lib/compliance.js
+++ b/lib/compliance.js
@@ -1,0 +1,239 @@
+'use strict';
+
+/**
+ * ABOUTME: Renders a per-PR skill-compliance trail from the ledger + observe-log.
+ * ABOUTME: Shows which rigid steps ran vs skipped, handoffs, gate overrides, hotfix.
+ *
+ * A worktree's .envoy/ledger.jsonl and .envoy/observe-log.jsonl ARE that branch's
+ * trail (the logs are per-worktree). This module reads both and answers: did the
+ * work flow through the rigid pickup→review→finalize→cleanup workflow, or skip
+ * steps? How many gate would-blocks were overridden (the false-positive signal)?
+ * And was any fast work a *sanctioned* hotfix rather than invisible skill-less work?
+ *
+ * The core is pure so tests can feed fixtures directly: `buildTrail` turns
+ * already-parsed event arrays into a trail model and `renderTrail` turns that
+ * model into a prose report. `compliance(dir)` is the thin IO wrapper that reads
+ * the two files and calls the pure core; missing files yield empty arrays and a
+ * clean "nothing recorded" report rather than a throw.
+ *
+ * Zero external dependencies.
+ *
+ * Usage:
+ *   node lib/compliance.js [dir]     # dir defaults to cwd
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { readLedger } = require(path.join(__dirname, 'ledger'));
+
+/** The rigid workflow steps, always shown in order. */
+const RIGID_STEPS = ['pickup', 'review', 'finalize', 'cleanup'];
+
+/** Skips a hotfix legitimately makes — not flagged as violations when hotfix ran. */
+const HOTFIX_SANCTIONED_SKIPS = new Set(['brainstorm', 'review']);
+
+const OBSERVE_LOG_REL = path.join('.envoy', 'observe-log.jsonl');
+
+/**
+ * Read all records from dir/.envoy/observe-log.jsonl. Missing file → []; corrupt
+ * lines are skipped rather than thrown on (mirrors readLedger's tolerance).
+ * @param {string} dir
+ * @returns {object[]}
+ */
+function readObserveLog(dir) {
+  let raw;
+  try {
+    raw = fs.readFileSync(path.join(dir, OBSERVE_LOG_REL), 'utf8');
+  } catch (_err) {
+    return [];
+  }
+  const records = [];
+  for (const line of raw.split('\n')) {
+    if (line.length === 0) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch (_err) {
+      // Skip a corrupt line — the log stays readable.
+    }
+  }
+  return records;
+}
+
+/**
+ * Build the trail model from already-parsed event arrays. Pure — no fs.
+ *
+ * @param {{ledger?: object[], observeLog?: object[]}} [input]
+ * @returns {TrailModel}
+ */
+function buildTrail(input = {}) {
+  const ledger = Array.isArray(input.ledger) ? input.ledger : [];
+  const observeLog = Array.isArray(input.observeLog) ? input.observeLog : [];
+
+  // First-seen ts per started skill.
+  const startedAt = {};
+  for (const e of ledger) {
+    if (e && e.type === 'skill-started' && e.skill && !(e.skill in startedAt)) {
+      startedAt[e.skill] = e.ts || null;
+    }
+  }
+
+  const hotfix = 'hotfix' in startedAt
+    ? { ran: true, ts: startedAt.hotfix }
+    : null;
+
+  // Steps: brainstorm only when it has a skill-started; then the rigid four.
+  const stepNames = [];
+  if ('brainstorm' in startedAt) stepNames.push('brainstorm');
+  stepNames.push(...RIGID_STEPS);
+
+  const steps = stepNames.map((skill) => {
+    const ran = skill in startedAt;
+    const step = { skill, ran, ts: ran ? startedAt[skill] : null };
+    if (!ran && hotfix && HOTFIX_SANCTIONED_SKIPS.has(skill)) {
+      step.sanctionedSkip = true;
+    }
+    return step;
+  });
+
+  const handoffs = ledger
+    .filter((e) => e && e.type === 'handoff-written')
+    .map((e) => ({ from: e.from || null, to: e.to || null, ts: e.ts || null }));
+
+  let overrides = 0;
+  let wouldBlock = 0;
+  for (const r of observeLog) {
+    if (r && r.kind === 'override') overrides += 1;
+    else wouldBlock += 1;
+  }
+
+  const label = ledgerLabel(ledger);
+
+  return {
+    branch: label.branch,
+    issue: label.issue,
+    steps,
+    handoffs,
+    overrides,
+    wouldBlock,
+    hotfix,
+    empty: ledger.length === 0 && observeLog.length === 0,
+  };
+}
+
+/**
+ * Derive the branch/issue label from the first ledger events that carry them.
+ * @param {object[]} ledger
+ * @returns {{branch: string|null, issue: number|null}}
+ */
+function ledgerLabel(ledger) {
+  let branch = null;
+  let issue = null;
+  for (const e of ledger) {
+    if (!e) continue;
+    if (branch === null && e.branch) branch = e.branch;
+    if (issue === null && e.issue !== undefined && e.issue !== null) issue = e.issue;
+    if (branch !== null && issue !== null) break;
+  }
+  return { branch, issue };
+}
+
+/**
+ * Render a trail model as a prose report string. Pure — no fs.
+ * @param {TrailModel} model
+ * @returns {string}
+ */
+function renderTrail(model) {
+  const heading = trailHeading(model);
+
+  if (model.empty) {
+    return `${heading}\n\nNothing recorded — this branch has no ledger or gate activity.\n`;
+  }
+
+  const lines = [heading, ''];
+
+  lines.push('Workflow steps:');
+  for (const step of model.steps) {
+    if (step.ran) {
+      lines.push(`  ✓ ${step.skill.padEnd(10)} ran ${step.ts}`);
+    } else if (step.sanctionedSkip) {
+      lines.push(`  ✗ ${step.skill.padEnd(10)} skipped (sanctioned — hotfix fast-path)`);
+    } else {
+      lines.push(`  ✗ ${step.skill.padEnd(10)} skipped`);
+    }
+  }
+  lines.push('');
+
+  lines.push('Handoffs:');
+  if (model.handoffs.length === 0) {
+    lines.push('  (none recorded)');
+  } else {
+    for (const h of model.handoffs) {
+      lines.push(`  ${h.from} → ${h.to}${h.ts ? ` (${h.ts})` : ''}`);
+    }
+  }
+  lines.push('');
+
+  if (model.hotfix) {
+    lines.push(
+      `Hotfix: sanctioned fast-path (ran ${model.hotfix.ts}) — a hotfix legitimately`,
+      '  skips brainstorm and review; this is tracked work, not skill-less.',
+      ''
+    );
+  }
+
+  lines.push(
+    `Gate overrides: ${model.overrides} override(s) across ${model.wouldBlock} would-block event(s).`
+  );
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Compose the report heading from the branch/issue label.
+ * @param {TrailModel} model
+ * @returns {string}
+ */
+function trailHeading(model) {
+  const branch = model.branch || '(unknown branch)';
+  const issue = model.issue !== null && model.issue !== undefined ? ` (issue #${model.issue})` : '';
+  return `Compliance trail — ${branch}${issue}`;
+}
+
+/**
+ * Read the ledger + observe-log under `dir/.envoy/` and render the trail. Missing
+ * files → empty arrays → a clean "nothing recorded" report; never throws on
+ * absent or corrupt logs.
+ * @param {string} dir
+ * @returns {string}
+ */
+function compliance(dir) {
+  const ledger = readLedger(dir);
+  const observeLog = readObserveLog(dir);
+  return renderTrail(buildTrail({ ledger, observeLog }));
+}
+
+function main() {
+  const dir = process.argv[2] || process.cwd();
+  process.stdout.write(compliance(dir));
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  buildTrail,
+  renderTrail,
+  compliance,
+  readObserveLog,
+};
+
+/**
+ * @typedef {Object} TrailModel
+ * @property {string|null} branch
+ * @property {number|null} issue
+ * @property {Array<{skill: string, ran: boolean, ts: string|null, sanctionedSkip?: boolean}>} steps
+ * @property {Array<{from: string|null, to: string|null, ts: string|null}>} handoffs
+ * @property {number} overrides - Count of {kind:'override'} observe-log records.
+ * @property {number} wouldBlock - Count of plain would-block observe-log records.
+ * @property {{ran: boolean, ts: string|null}|null} hotfix
+ * @property {boolean} empty - True when neither log had any records.
+ */

--- a/skills/cleanup/preflight.js
+++ b/skills/cleanup/preflight.js
@@ -16,6 +16,7 @@ const path = require('path');
 const CWD = process.cwd();
 const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..');
 const { readActiveSkill, clearActiveSkill } = require(path.join(REPO_ROOT, 'lib', 'active-skill'));
+const { appendEvent } = require(path.join(REPO_ROOT, 'lib', 'ledger'));
 
 function say(line) { process.stdout.write(`${line}\n`); }
 function banner(tier) { say(`## STATUS: ${tier}`); }
@@ -23,6 +24,7 @@ function banner(tier) { say(`## STATUS: ${tier}`); }
 function main() {
   const priorMarker = readActiveSkill(CWD);
   clearActiveSkill(CWD);
+  appendEvent(CWD, { type: 'skill-started', skill: 'cleanup', issue: priorMarker ? priorMarker.issueNumber : undefined });
 
   const statePath = path.join(CWD, '.envoy', 'finalize', 'state.json');
   banner('ok');

--- a/skills/coderabbit-pr-review/preflight.js
+++ b/skills/coderabbit-pr-review/preflight.js
@@ -13,6 +13,7 @@ const path = require('path');
 const CWD = process.cwd();
 const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..');
 const { validateFile } = require(path.join(REPO_ROOT, 'lib', 'validate-schema'));
+const { appendEvent } = require(path.join(REPO_ROOT, 'lib', 'ledger'));
 
 function say(line) { process.stdout.write(`${line}\n`); }
 function banner(tier) { say(`## STATUS: ${tier}`); }
@@ -59,6 +60,7 @@ function main() {
     startedAt: nowIso(),
     pid: process.pid,
   });
+  appendEvent(CWD, { type: 'skill-started', skill: 'coderabbit-pr-review', issue: state.issueNumber });
 
   banner('ok');
   say('');

--- a/skills/finalize/preflight.js
+++ b/skills/finalize/preflight.js
@@ -15,6 +15,7 @@ const path = require('path');
 const CWD = process.cwd();
 const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..');
 const { validateFile } = require(path.join(REPO_ROOT, 'lib', 'validate-schema'));
+const { appendEvent } = require(path.join(REPO_ROOT, 'lib', 'ledger'));
 
 function say(line) { process.stdout.write(`${line}\n`); }
 function banner(tier) { say(`## STATUS: ${tier}`); }
@@ -76,6 +77,7 @@ function main() {
     startedAt: nowIso(),
     pid: process.pid,
   });
+  appendEvent(CWD, { type: 'skill-started', skill: 'finalize', issue: handoff.issueNumber });
 
   banner('ok');
   say('');

--- a/skills/fix-ci/preflight.js
+++ b/skills/fix-ci/preflight.js
@@ -16,6 +16,7 @@ const path = require('path');
 const CWD = process.cwd();
 const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..');
 const { validateFile } = require(path.join(REPO_ROOT, 'lib', 'validate-schema'));
+const { appendEvent } = require(path.join(REPO_ROOT, 'lib', 'ledger'));
 
 function say(line) { process.stdout.write(`${line}\n`); }
 function banner(tier) { say(`## STATUS: ${tier}`); }
@@ -84,6 +85,7 @@ function main() {
     startedAt: nowIso(),
     pid: process.pid,
   });
+  appendEvent(CWD, { type: 'skill-started', skill: 'fix-ci', issue: state.issueNumber });
 
   banner('ok');
   say('');

--- a/skills/hotfix/SKILL.md
+++ b/skills/hotfix/SKILL.md
@@ -75,7 +75,9 @@ git worktree add ".worktrees/hotfix-$TOPIC" -b "hotfix/$ISSUE_NUMBER-$TOPIC" mai
 cd ".worktrees/hotfix-$TOPIC"
 # Only now, with the worktree existing and cwd anchored in it, record state:
 mkdir -p .envoy
-node -e "require('fs').writeFileSync('.envoy/active-skill.json', JSON.stringify({\$schemaVersion:'1',skill:'hotfix',issueNumber:Number(process.env.ISSUE_NUMBER),startedAt:new Date().toISOString()},null,2))" ISSUE_NUMBER="$ISSUE_NUMBER"
+# NOTE: the env assignment is a PREFIX before `node` — a suffix (`node -e "..." VAR=val`)
+# becomes argv, not process.env, so issueNumber would be NaN. Keep it a prefix.
+ISSUE_NUMBER="$ISSUE_NUMBER" node -e "const fs=require('fs'); const issue=Number(process.env.ISSUE_NUMBER); fs.writeFileSync('.envoy/active-skill.json', JSON.stringify({\$schemaVersion:'1',skill:'hotfix',issueNumber:issue,startedAt:new Date().toISOString()},null,2)); require('${CLAUDE_SKILL_DIR}/../../lib/ledger').appendEvent(process.cwd(), {type:'skill-started', skill:'hotfix', issue:issue});"
 ```
 
 Writing `.envoy/active-skill.json` here keeps the hotfix visible to the

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -182,6 +182,8 @@ const handoff = {
 
 fs.mkdirSync('.envoy/review', { recursive: true });
 fs.writeFileSync('.envoy/review/handoff-to-finalize.json', JSON.stringify(handoff, null, 2));
+
+require('../../lib/ledger').appendEvent(process.cwd(), { type: 'handoff-written', from: 'review', to: 'finalize' });
 ```
 
 Finalize preflight requires `reviewStatus === "approved"`; any other value blocks finalize.

--- a/skills/review/preflight.js
+++ b/skills/review/preflight.js
@@ -16,6 +16,7 @@ const { execSync } = require('child_process');
 const CWD = process.cwd();
 const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..');
 const { validateFile } = require(path.join(REPO_ROOT, 'lib', 'validate-schema'));
+const { appendEvent } = require(path.join(REPO_ROOT, 'lib', 'ledger'));
 
 function say(line) { process.stdout.write(`${line}\n`); }
 function banner(tier) { say(`## STATUS: ${tier}`); }
@@ -88,6 +89,7 @@ function main() {
     startedAt: nowIso(),
     pid: process.pid,
   });
+  appendEvent(CWD, { type: 'skill-started', skill: 'review', issue: handoff.issueNumber });
 
   if (warnings.length > 0) {
     const tier = strictPromote('degraded');

--- a/skills/wiki-sync/preflight.js
+++ b/skills/wiki-sync/preflight.js
@@ -12,6 +12,8 @@ const fs = require('fs');
 const path = require('path');
 
 const CWD = process.cwd();
+const REPO_ROOT = process.env.ENVOY_REPO_ROOT || path.resolve(__dirname, '..', '..');
+const { appendEvent } = require(path.join(REPO_ROOT, 'lib', 'ledger'));
 
 function say(line) { process.stdout.write(`${line}\n`); }
 function banner(tier) { say(`## STATUS: ${tier}`); }
@@ -58,6 +60,7 @@ function main() {
     startedAt: nowIso(),
     pid: process.pid,
   });
+  appendEvent(CWD, { type: 'skill-started', skill: 'wiki-sync' });
 
   const hasHome = files.includes('Home.md');
   if (!hasHome) {

--- a/tests/lib/compliance.test.js
+++ b/tests/lib/compliance.test.js
@@ -1,0 +1,369 @@
+#!/usr/bin/env node
+/**
+ * ABOUTME: Tests the per-PR skill-compliance trail (lib/compliance.js): pure
+ * ABOUTME: buildTrail/renderTrail over fixtures + compliance(dir) IO over temp dirs.
+ *
+ * Run: node tests/lib/compliance.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const LIB = path.join(__dirname, '..', '..', 'lib');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeLines(dir, rel, lines) {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, lines.map((l) => (typeof l === 'string' ? l : JSON.stringify(l))).join('\n') + '\n');
+}
+
+const compliance = require(path.join(LIB, 'compliance'));
+
+// Fixtures ──────────────────────────────────────────────────────────
+
+function fullFlowLedger() {
+  const b = 'feature/41-compliance';
+  return [
+    { ts: '2026-07-21T10:00:00.000Z', branch: b, issue: 41, type: 'skill-started', skill: 'pickup' },
+    { ts: '2026-07-21T10:30:00.000Z', branch: b, issue: 41, type: 'handoff-written', from: 'pickup', to: 'review' },
+    { ts: '2026-07-21T11:00:00.000Z', branch: b, issue: 41, type: 'skill-started', skill: 'review' },
+    { ts: '2026-07-21T11:30:00.000Z', branch: b, issue: 41, type: 'handoff-written', from: 'review', to: 'finalize' },
+    { ts: '2026-07-21T12:00:00.000Z', branch: b, issue: 41, type: 'skill-started', skill: 'finalize' },
+    { ts: '2026-07-21T13:00:00.000Z', branch: b, issue: 41, type: 'skill-started', skill: 'cleanup' },
+  ];
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Exports
+// ═══════════════════════════════════════════════════════════════════
+
+section('exports');
+
+test('buildTrail is exported', () => {
+  assert.strictEqual(typeof compliance.buildTrail, 'function');
+});
+
+test('renderTrail is exported', () => {
+  assert.strictEqual(typeof compliance.renderTrail, 'function');
+});
+
+test('compliance is exported', () => {
+  assert.strictEqual(typeof compliance.compliance, 'function');
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// buildTrail — pure, over already-parsed arrays
+// ═══════════════════════════════════════════════════════════════════
+
+section('buildTrail: full flow → all rigid steps ran');
+
+test('marks pickup/review/finalize/cleanup ran with their ts', () => {
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog: [] });
+  const byName = Object.fromEntries(m.steps.map((s) => [s.skill, s]));
+  assert.strictEqual(byName.pickup.ran, true);
+  assert.strictEqual(byName.pickup.ts, '2026-07-21T10:00:00.000Z');
+  assert.strictEqual(byName.review.ran, true);
+  assert.strictEqual(byName.finalize.ran, true);
+  assert.strictEqual(byName.cleanup.ran, true);
+});
+
+test('carries branch + issue label from ledger events', () => {
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog: [] });
+  assert.strictEqual(m.branch, 'feature/41-compliance');
+  assert.strictEqual(m.issue, 41);
+});
+
+test('surfaces handoffs from handoff-written events', () => {
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog: [] });
+  assert.strictEqual(m.handoffs.length, 2);
+  assert.deepStrictEqual(
+    m.handoffs.map((h) => `${h.from}->${h.to}`),
+    ['pickup->review', 'review->finalize']
+  );
+});
+
+test('not empty when events present', () => {
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog: [] });
+  assert.strictEqual(m.empty, false);
+});
+
+section('buildTrail: skipped-step flow');
+
+test('marks finalize + cleanup skipped when no skill-started for them', () => {
+  const ledger = fullFlowLedger().filter(
+    (e) => !(e.type === 'skill-started' && (e.skill === 'finalize' || e.skill === 'cleanup'))
+  );
+  const m = compliance.buildTrail({ ledger, observeLog: [] });
+  const byName = Object.fromEntries(m.steps.map((s) => [s.skill, s]));
+  assert.strictEqual(byName.pickup.ran, true);
+  assert.strictEqual(byName.review.ran, true);
+  assert.strictEqual(byName.finalize.ran, false);
+  assert.strictEqual(byName.finalize.ts, null);
+  assert.strictEqual(byName.cleanup.ran, false);
+});
+
+section('buildTrail: brainstorm only surfaced when present');
+
+test('brainstorm absent from steps when no skill-started for it', () => {
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog: [] });
+  assert.ok(!m.steps.some((s) => s.skill === 'brainstorm'));
+});
+
+test('brainstorm surfaced (ran) when a skill-started exists', () => {
+  const ledger = [
+    { ts: '2026-07-21T09:00:00.000Z', branch: 'b', type: 'skill-started', skill: 'brainstorm' },
+    ...fullFlowLedger(),
+  ];
+  const m = compliance.buildTrail({ ledger, observeLog: [] });
+  const brainstorm = m.steps.find((s) => s.skill === 'brainstorm');
+  assert.ok(brainstorm, 'brainstorm step should be present');
+  assert.strictEqual(brainstorm.ran, true);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// buildTrail — gate overrides (false-positive evidence)
+// ═══════════════════════════════════════════════════════════════════
+
+section('buildTrail: override + would-block counts');
+
+test('counts override records and plain would-block events separately', () => {
+  const observeLog = [
+    { ts: '2026-07-21T11:10:00.000Z', skill: 'review', gate: 'stop-audit', reason: 'unmet' },
+    { kind: 'override', ts: '2026-07-21T11:10:00.000Z', skill: 'review', gate: 'stop-audit', reason: 'unmet' },
+    { ts: '2026-07-21T11:20:00.000Z', skill: 'pickup', gate: 'agent-guard', reason: 'guard', tool: 'Agent' },
+  ];
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog });
+  assert.strictEqual(m.overrides, 1);
+  assert.strictEqual(m.wouldBlock, 2);
+});
+
+test('zero overrides + zero would-block on empty observe-log', () => {
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog: [] });
+  assert.strictEqual(m.overrides, 0);
+  assert.strictEqual(m.wouldBlock, 0);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// buildTrail — hotfix as sanctioned fast-path
+// ═══════════════════════════════════════════════════════════════════
+
+section('buildTrail: hotfix sanctioned fast-path');
+
+test('flags hotfix as ran when a hotfix skill-started exists', () => {
+  const ledger = [
+    { ts: '2026-07-22T08:00:00.000Z', branch: 'hotfix/99-crash', issue: 99, type: 'skill-started', skill: 'hotfix' },
+  ];
+  const m = compliance.buildTrail({ ledger, observeLog: [] });
+  assert.ok(m.hotfix, 'hotfix should be present');
+  assert.strictEqual(m.hotfix.ran, true);
+  assert.strictEqual(m.hotfix.ts, '2026-07-22T08:00:00.000Z');
+});
+
+test('hotfix null when no hotfix activity', () => {
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog: [] });
+  assert.strictEqual(m.hotfix, null);
+});
+
+test('review/brainstorm skips marked sanctioned when hotfix ran', () => {
+  const ledger = [
+    { ts: '2026-07-22T08:00:00.000Z', branch: 'hotfix/99-crash', issue: 99, type: 'skill-started', skill: 'hotfix' },
+  ];
+  const m = compliance.buildTrail({ ledger, observeLog: [] });
+  const review = m.steps.find((s) => s.skill === 'review');
+  assert.strictEqual(review.ran, false);
+  assert.strictEqual(review.sanctionedSkip, true);
+});
+
+test('review skip NOT sanctioned when hotfix did not run', () => {
+  const ledger = fullFlowLedger().filter((e) => !(e.type === 'skill-started' && e.skill === 'review'));
+  const m = compliance.buildTrail({ ledger, observeLog: [] });
+  const review = m.steps.find((s) => s.skill === 'review');
+  assert.strictEqual(review.ran, false);
+  assert.ok(!review.sanctionedSkip);
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// buildTrail — empty
+// ═══════════════════════════════════════════════════════════════════
+
+section('buildTrail: empty inputs');
+
+test('empty flag true, no branch/issue, when both inputs empty', () => {
+  const m = compliance.buildTrail({ ledger: [], observeLog: [] });
+  assert.strictEqual(m.empty, true);
+  assert.strictEqual(m.branch, null);
+  assert.strictEqual(m.issue, null);
+});
+
+test('does not throw when called with no argument', () => {
+  assert.doesNotThrow(() => compliance.buildTrail());
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// renderTrail — prose string
+// ═══════════════════════════════════════════════════════════════════
+
+section('renderTrail: prose output');
+
+test('full flow render shows branch, ran steps, handoffs', () => {
+  const m = compliance.buildTrail({ ledger: fullFlowLedger(), observeLog: [] });
+  const out = compliance.renderTrail(m);
+  assert.strictEqual(typeof out, 'string');
+  assert.ok(out.includes('feature/41-compliance'), 'branch label');
+  assert.ok(out.includes('#41'), 'issue label');
+  assert.ok(/✓\s+pickup/.test(out), 'pickup ran');
+  assert.ok(/✓\s+finalize/.test(out), 'finalize ran');
+  assert.ok(out.includes('pickup') && out.includes('review'), 'handoff mention');
+});
+
+test('skipped steps rendered with ✗', () => {
+  const ledger = fullFlowLedger().filter(
+    (e) => !(e.type === 'skill-started' && (e.skill === 'finalize' || e.skill === 'cleanup'))
+  );
+  const out = compliance.renderTrail(compliance.buildTrail({ ledger, observeLog: [] }));
+  assert.ok(/✗\s+finalize/.test(out), 'finalize skipped shown');
+  assert.ok(/✗\s+cleanup/.test(out), 'cleanup skipped shown');
+});
+
+test('override count rendered', () => {
+  const observeLog = [
+    { ts: '2026-07-21T11:10:00.000Z', skill: 'review', gate: 'stop-audit', reason: 'unmet' },
+    { kind: 'override', ts: '2026-07-21T11:10:00.000Z', skill: 'review', gate: 'stop-audit', reason: 'unmet' },
+  ];
+  const out = compliance.renderTrail(compliance.buildTrail({ ledger: fullFlowLedger(), observeLog }));
+  assert.ok(/override/i.test(out), 'override mentioned');
+  assert.ok(out.includes('1'), 'override count 1 shown');
+});
+
+test('hotfix rendered as sanctioned fast-path', () => {
+  const ledger = [
+    { ts: '2026-07-22T08:00:00.000Z', branch: 'hotfix/99-crash', issue: 99, type: 'skill-started', skill: 'hotfix' },
+  ];
+  const out = compliance.renderTrail(compliance.buildTrail({ ledger, observeLog: [] }));
+  assert.ok(/sanctioned/i.test(out), 'sanctioned mentioned');
+  assert.ok(/fast.?path/i.test(out), 'fast-path mentioned');
+});
+
+test('empty render is a clean nothing-recorded report', () => {
+  const out = compliance.renderTrail(compliance.buildTrail({ ledger: [], observeLog: [] }));
+  assert.ok(/nothing recorded/i.test(out), 'nothing-recorded message');
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// compliance(dir) — IO wrapper over temp dirs
+// ═══════════════════════════════════════════════════════════════════
+
+section('compliance(dir): reads ledger + observe-log from dir/.envoy');
+
+test('renders a trail from on-disk ledger + observe-log', () => {
+  const dir = makeTmp('compliance-io-');
+  try {
+    writeLines(dir, '.envoy/ledger.jsonl', fullFlowLedger());
+    writeLines(dir, '.envoy/observe-log.jsonl', [
+      { ts: '2026-07-21T11:10:00.000Z', skill: 'review', gate: 'stop-audit', reason: 'unmet' },
+      { kind: 'override', ts: '2026-07-21T11:10:00.000Z', skill: 'review', gate: 'stop-audit', reason: 'unmet' },
+    ]);
+    const out = compliance.compliance(dir);
+    assert.ok(out.includes('feature/41-compliance'));
+    assert.ok(/✓\s+pickup/.test(out));
+    assert.ok(/override/i.test(out));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('hotfix flow via disk renders sanctioned fast-path', () => {
+  const dir = makeTmp('compliance-hotfix-');
+  try {
+    writeLines(dir, '.envoy/ledger.jsonl', [
+      { ts: '2026-07-22T08:00:00.000Z', branch: 'hotfix/99-crash', issue: 99, type: 'skill-started', skill: 'hotfix' },
+    ]);
+    const out = compliance.compliance(dir);
+    assert.ok(/sanctioned/i.test(out));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+section('compliance(dir): missing/empty/corrupt → clean, no throw');
+
+test('missing files → nothing-recorded report, no throw', () => {
+  const dir = makeTmp('compliance-missing-');
+  try {
+    let out;
+    assert.doesNotThrow(() => {
+      out = compliance.compliance(dir);
+    });
+    assert.ok(/nothing recorded/i.test(out));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('corrupt observe-log lines tolerated', () => {
+  const dir = makeTmp('compliance-corrupt-');
+  try {
+    writeLines(dir, '.envoy/ledger.jsonl', fullFlowLedger());
+    fs.writeFileSync(
+      path.join(dir, '.envoy', 'observe-log.jsonl'),
+      `${JSON.stringify({ ts: 't', skill: 'review', gate: 'stop-audit', reason: 'x' })}\n{ not json\n${JSON.stringify({ kind: 'override', ts: 't', skill: 'review', gate: 'stop-audit', reason: 'x' })}\n`,
+      'utf8'
+    );
+    let out;
+    assert.doesNotThrow(() => {
+      out = compliance.compliance(dir);
+    });
+    const m = compliance.buildTrail({
+      ledger: fullFlowLedger(),
+      observeLog: compliance.readObserveLog(dir),
+    });
+    assert.strictEqual(m.overrides, 1);
+    assert.strictEqual(m.wouldBlock, 1);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('readObserveLog missing file → []', () => {
+  const dir = makeTmp('compliance-obsread-');
+  try {
+    assert.deepStrictEqual(compliance.readObserveLog(dir), []);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Summary
+// ═══════════════════════════════════════════════════════════════════
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/lifecycle-events.test.js
+++ b/tests/lib/lifecycle-events.test.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * ABOUTME: Verifies every rigid skill's preflight emits a `skill-started`
+ * ABOUTME: ledger event, and the review→finalize handoff emits `handoff-written`.
+ *
+ * Run: node tests/lib/lifecycle-events.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeJson(dir, rel, data) {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, JSON.stringify(data, null, 2));
+}
+
+function readLedger(dir) {
+  const p = path.join(dir, '.envoy', 'ledger.jsonl');
+  let raw;
+  try {
+    raw = fs.readFileSync(p, 'utf8');
+  } catch (_err) {
+    return [];
+  }
+  return raw
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+function runPreflight(skillDir, dir, env = {}) {
+  const preflight = path.join(REPO_ROOT, 'skills', skillDir, 'preflight.js');
+  return spawnSync('node', [preflight], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+// Seeds the state each preflight reads so it reaches its appendEvent call.
+const CASES = [
+  {
+    skillDir: 'review',
+    skill: 'review',
+    issue: 41,
+    seed(dir) {
+      writeJson(dir, '.envoy/pickup/handoff-to-review.json', {
+        $schemaVersion: '1',
+        issueNumber: 41,
+        branch: 'feature/41-compliance',
+        baseSha: 'aaaaaaa',
+        headSha: 'bbbbbbb',
+        tasksCompleted: [{ id: 'task-1', commitSha: 'aaaaaaa' }],
+      });
+    },
+  },
+  {
+    skillDir: 'finalize',
+    skill: 'finalize',
+    issue: 41,
+    seed(dir) {
+      writeJson(dir, '.envoy/review/handoff-to-finalize.json', {
+        $schemaVersion: '1',
+        issueNumber: 41,
+        branch: 'feature/41-compliance',
+        reviewStatus: 'approved',
+        layers: [{ name: 'lint', status: 'passed', findings: 0 }],
+      });
+    },
+  },
+  {
+    skillDir: 'cleanup',
+    skill: 'cleanup',
+    issue: undefined,
+    seed() {},
+  },
+  {
+    skillDir: 'fix-ci',
+    skill: 'fix-ci',
+    issue: 41,
+    seed(dir) {
+      writeJson(dir, '.envoy/finalize/state.json', {
+        $schemaVersion: '1',
+        issueNumber: 41,
+        branch: 'feature/41-compliance',
+        prNumber: 7,
+      });
+    },
+  },
+  {
+    skillDir: 'wiki-sync',
+    skill: 'wiki-sync',
+    issue: undefined,
+    seed(dir) {
+      const wiki = path.join(dir, 'docs', 'wiki');
+      fs.mkdirSync(wiki, { recursive: true });
+      fs.writeFileSync(path.join(wiki, 'Home.md'), '# Home\n');
+    },
+  },
+  {
+    skillDir: 'coderabbit-pr-review',
+    skill: 'coderabbit-pr-review',
+    issue: 41,
+    seed(dir) {
+      writeJson(dir, '.envoy/finalize/state.json', {
+        $schemaVersion: '1',
+        issueNumber: 41,
+        branch: 'feature/41-compliance',
+        prNumber: 7,
+      });
+    },
+  },
+];
+
+section('preflights emit skill-started into .envoy/ledger.jsonl');
+
+for (const c of CASES) {
+  test(`${c.skillDir} preflight appends skill-started (skill=${c.skill})`, () => {
+    const dir = makeTmp(`lifecycle-${c.skillDir}-`);
+    try {
+      c.seed(dir);
+      const res = runPreflight(c.skillDir, dir);
+      const events = readLedger(dir);
+      const started = events.filter((e) => e.type === 'skill-started');
+      assert.strictEqual(
+        started.length,
+        1,
+        `expected exactly one skill-started event, got ${started.length}. stdout:\n${res.stdout}\nstderr:\n${res.stderr}`
+      );
+      assert.strictEqual(started[0].skill, c.skill, `skill name mismatch`);
+      if (c.issue !== undefined) {
+        assert.strictEqual(started[0].issue, c.issue, `issue mismatch for ${c.skillDir}`);
+      }
+    } finally {
+      cleanup(dir);
+    }
+  });
+}
+
+section('preflight output not regressed by the ledger write');
+
+for (const c of CASES) {
+  test(`${c.skillDir} preflight still prints a STATUS banner`, () => {
+    const dir = makeTmp(`lifecycle-status-${c.skillDir}-`);
+    try {
+      c.seed(dir);
+      const res = runPreflight(c.skillDir, dir);
+      assert.ok(
+        /## STATUS: (ok|degraded|fatal)/.test(res.stdout),
+        `expected a STATUS banner, got:\n${res.stdout}`
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+}
+
+section('review→finalize handoff emits handoff-written');
+
+test('review SKILL.md appends handoff-written after writing the finalize handoff', () => {
+  const skill = fs.readFileSync(path.join(REPO_ROOT, 'skills', 'review', 'SKILL.md'), 'utf8');
+  const writeIdx = skill.indexOf("handoff-to-finalize.json");
+  assert.ok(writeIdx !== -1, 'expected the finalize handoff write in review SKILL.md');
+  assert.ok(
+    /appendEvent\([^)]*\{\s*type:\s*'handoff-written'[^}]*from:\s*'review'[^}]*to:\s*'finalize'/.test(skill),
+    'expected an appendEvent handoff-written(from:review,to:finalize) call'
+  );
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/lifecycle-events.test.js
+++ b/tests/lib/lifecycle-events.test.js
@@ -194,7 +194,7 @@ test('review SKILL.md appends handoff-written after writing the finalize handoff
   const writeIdx = skill.indexOf("handoff-to-finalize.json");
   assert.ok(writeIdx !== -1, 'expected the finalize handoff write in review SKILL.md');
   assert.ok(
-    /appendEvent\([^)]*\{\s*type:\s*'handoff-written'[^}]*from:\s*'review'[^}]*to:\s*'finalize'/.test(skill),
+    /appendEvent\([\s\S]*?type:\s*'handoff-written'[\s\S]*?from:\s*'review'[\s\S]*?to:\s*'finalize'/.test(skill),
     'expected an appendEvent handoff-written(from:review,to:finalize) call'
   );
 });

--- a/tests/lib/lifecycle-events.test.js
+++ b/tests/lib/lifecycle-events.test.js
@@ -199,5 +199,29 @@ test('review SKILL.md appends handoff-written after writing the finalize handoff
   );
 });
 
+section('hotfix emits skill-started (sanctioned fast-path) without the NaN env bug');
+
+test('hotfix SKILL.md emits a skill-started(hotfix) ledger event', () => {
+  const skill = fs.readFileSync(path.join(REPO_ROOT, 'skills', 'hotfix', 'SKILL.md'), 'utf8');
+  assert.ok(
+    /appendEvent\([\s\S]*?type:\s*'skill-started'[\s\S]*?skill:\s*'hotfix'/.test(skill),
+    'expected an appendEvent skill-started(hotfix) call so compliance can flag the sanctioned fast-path'
+  );
+});
+
+test('hotfix active-skill write passes ISSUE_NUMBER as an env prefix, not a node argv suffix', () => {
+  const skill = fs.readFileSync(path.join(REPO_ROOT, 'skills', 'hotfix', 'SKILL.md'), 'utf8');
+  // The bug (#43 family): `node -e "..." ISSUE_NUMBER="$ISSUE_NUMBER"` -> argv, so
+  // process.env.ISSUE_NUMBER is undefined -> issueNumber: NaN.
+  assert.ok(
+    !/node -e "[\s\S]*?"\s*ISSUE_NUMBER=/.test(skill),
+    'ISSUE_NUMBER must be an env prefix before node, not a suffix after it (else NaN)'
+  );
+  assert.ok(
+    /ISSUE_NUMBER="\$ISSUE_NUMBER"\s+node -e/.test(skill),
+    'expected the env-prefix form: ISSUE_NUMBER="$ISSUE_NUMBER" node -e "..."'
+  );
+});
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
A per-PR **compliance trail**: given a branch, did the work flow through pickup -> review -> finalize, or skip steps? Reads the ledger (#66) + observe-log (#60), so it also produces the false-positive evidence for arming strict. **Closes #41.** (Phase 6 was unblocked by the ledger.)

## Changes
- **task-1 — complete lifecycle emission:** `skill-started` now emitted from review/finalize/cleanup/fix-ci/wiki-sync/coderabbit-pr-review preflights (pickup already did), plus `handoff-written` at review->finalize. So the ledger records the whole flow.
- **task-2 — `lib/compliance.js`:** `node lib/compliance.js [dir]` renders a prose trail — steps ran/skipped, handoffs, gate-override count, and **hotfix flagged as a sanctioned fast-path** (not skill-less). Pure `buildTrail`/`renderTrail` split from IO; missing/corrupt files tolerated.
- **Also fixed a real bug:** hotfix `SKILL.md` wrote its active-skill marker with `node -e \"...\" ISSUE_NUMBER=...` (a #43-family env-suffix bug -> `issueNumber: NaN`). Fixed to an env-prefix and wired hotfix to emit its ledger event, so the hotfix-sanctioned trail is live, not latent.

## Reviewed
Override counting verified against observe-gate's two-line override behavior (no double-count). Pure/IO separation clean, fail-soft on missing/corrupt logs, hotfix fix verified end-to-end (issueNumber real, not NaN).

## Test Plan
- [x] `node scripts/run-tests.js` — 31 files green (compliance.test.js 28, lifecycle-events.test.js 15)

## Linked Issue
Closes #41

---

*Created with Envoy*