### PR TITLE
issue-guard hook: gh issue create always prompts for approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Envoy uses hooks for automation without polluting the context window:
 | Hook | Type | Purpose |
 |------|------|---------|
 | `config-protection` | PreToolUse | Blocks linter/formatter config modifications |
+| `issue-guard` | PreToolUse | Forces a manual approval prompt on `gh issue create` |
 | `post-edit-accumulator` | PostToolUse | Tracks edited files for batched processing |
 | `post-pr-poll` | PostToolUse | Triggers CodeRabbit polling after PR creation |
 | `stop-batch-lint` | Stop | Runs lint once across all session edits |
@@ -254,7 +255,7 @@ Control which hooks run via `ENVOY_HOOK_PROFILE`:
 
 | Profile | Hooks | Use Case |
 |---------|-------|----------|
-| `minimal` | config-protection, cost-tracker | Low overhead, essential protection |
+| `minimal` | config-protection, issue-guard, cost-tracker | Low overhead, essential protection |
 | `standard` | All hooks (default) | Full automation |
 | `strict` | All hooks + verification gates | Maximum safety |
 

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -25,6 +25,7 @@ Hooks receive JSON on stdin describing the event. They control behavior via exit
 |------|-------|---------|
 | `session-start.sh` | SessionStart | Loads Envoy skills, detects tech stacks, restores session state |
 | `config-protection.js` | PreToolUse (Edit/Write) | Blocks linter/formatter config modifications |
+| `issue-guard.js` | PreToolUse (Bash) | Forces a manual approval prompt on `gh issue create` |
 | `post-edit-accumulator.js` | PostToolUse (Edit/Write) | Tracks edited files for batched processing |
 | `post-pr-poll.js` | PostToolUse (Bash) | Triggers CodeRabbit polling after `gh pr create` |
 | `stop-batch-lint.js` | Stop | Runs lint once across all session edits |
@@ -55,7 +56,7 @@ All hooks route through `hook-runner.js` which checks `ENVOY_HOOK_PROFILE`:
 
 | Profile | Hooks | Use Case |
 |---------|-------|----------|
-| `minimal` | session-start, config-protection | Lowest overhead |
+| `minimal` | session-start, config-protection, issue-guard | Lowest overhead |
 | `standard` | All hooks (default) | Full automation |
 | `strict` | All hooks + future verification gates | Maximum safety |
 

--- a/hooks/hook-runner.js
+++ b/hooks/hook-runner.js
@@ -23,6 +23,7 @@ const path = require('path');
 const HOOK_PROFILES = {
   'session-start':          ['minimal', 'standard', 'strict'],
   'config-protection':      ['minimal', 'standard', 'strict'],
+  'issue-guard':            ['minimal', 'standard', 'strict'],
   'pre-compact':            ['minimal', 'standard', 'strict'],
   'post-edit-accumulator':  ['standard', 'strict'],
   'stop-batch-lint':        ['standard', 'strict'],

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -32,6 +32,16 @@
             "_profiles": ["minimal", "standard", "strict"]
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/hook-runner.js\" issue-guard",
+            "_profiles": ["minimal", "standard", "strict"]
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/hooks/issue-guard.js
+++ b/hooks/issue-guard.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * ABOUTME: PreToolUse[Bash] guard: a command containing `gh issue create`
+ * ABOUTME: gets permissionDecision "ask" so issue creation always needs user approval.
+ *
+ * Issues are born through brainstorm/hotfix after the user says go — never
+ * on the model's own initiative. This guard does not block: it forces a
+ * manual permission prompt, overriding any Bash allowlist rule.
+ *
+ * FAIL-OPEN: any error is swallowed and we return 0 with no output. A broken
+ * guard must never affect a tool call.
+ */
+
+const REASON =
+  'Self-initiated issue creation is not allowed (first time right). ' +
+  'Approve only if you asked for this issue.';
+
+/**
+ * Evaluate one PreToolUse event.
+ * @param {string|object} rawInput raw stdin payload (the tool-use event JSON)
+ * @returns {number} exit code: always 0; the ask decision travels via stdout
+ */
+function run(rawInput) {
+  try {
+    const input = typeof rawInput === 'string' ? JSON.parse(rawInput) : rawInput;
+    if ((input.tool_name || '') !== 'Bash') return 0;
+
+    const command = input.tool_input?.command || '';
+    if (!command.includes('gh issue create')) return 0;
+
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'ask',
+        permissionDecisionReason: REASON,
+      },
+    }));
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+module.exports = { run };

--- a/tests/hooks/issue-guard.test.js
+++ b/tests/hooks/issue-guard.test.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * ABOUTME: Tests the issue-guard PreToolUse hook: gh issue create must
+ * ABOUTME: trigger a permissionDecision "ask"; everything else stays silent.
+ *
+ * Run: node tests/hooks/issue-guard.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const HOOKS = path.join(__dirname, '..', '..', 'hooks');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+function section(name) {
+  process.stdout.write(`\n\x1b[1m${name}\x1b[0m\n`);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Load module
+// ═══════════════════════════════════════════════════════════════════
+
+const hook = require(path.join(HOOKS, 'issue-guard'));
+
+/**
+ * Run hook.run(input) capturing console.log output.
+ * @param {string} input raw stdin payload
+ * @returns {{code: number, lines: string[]}}
+ */
+function runCaptured(input) {
+  const lines = [];
+  const original = console.log;
+  console.log = (msg) => lines.push(String(msg));
+  let code;
+  try {
+    code = hook.run(input);
+  } finally {
+    console.log = original;
+  }
+  return { code: typeof code === 'number' ? code : 0, lines };
+}
+
+function bashEvent(command) {
+  return JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════
+
+section('asks on gh issue create');
+
+test('plain gh issue create emits permissionDecision ask', () => {
+  const { code, lines } = runCaptured(bashEvent('gh issue create --title "x" --body "y"'));
+  assert.strictEqual(code, 0, 'must exit 0 so the ask decision is honored');
+  assert.strictEqual(lines.length, 1, 'exactly one JSON line on stdout');
+  const out = JSON.parse(lines[0]);
+  assert.strictEqual(out.hookSpecificOutput.hookEventName, 'PreToolUse');
+  assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'ask');
+  assert.ok(out.hookSpecificOutput.permissionDecisionReason.length > 0);
+});
+
+test('gh issue create inside a compound command still asks', () => {
+  const { lines } = runCaptured(bashEvent('cd /tmp && gh issue create --title t'));
+  assert.strictEqual(lines.length, 1);
+  assert.strictEqual(JSON.parse(lines[0]).hookSpecificOutput.permissionDecision, 'ask');
+});
+
+section('stays silent otherwise');
+
+test('unrelated command produces no output', () => {
+  const { code, lines } = runCaptured(bashEvent('ls -la'));
+  assert.strictEqual(code, 0);
+  assert.strictEqual(lines.length, 0);
+});
+
+test('other gh subcommands produce no output', () => {
+  for (const cmd of ['gh issue list', 'gh issue edit 12', 'gh pr create --title t']) {
+    const { lines } = runCaptured(bashEvent(cmd));
+    assert.strictEqual(lines.length, 0, `expected silence for: ${cmd}`);
+  }
+});
+
+test('non-Bash tool event produces no output', () => {
+  const { lines } = runCaptured(JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: '/tmp/gh issue create.md' },
+  }));
+  assert.strictEqual(lines.length, 0);
+});
+
+section('fails open');
+
+test('malformed JSON input is silent and exits 0', () => {
+  const { code, lines } = runCaptured('not json at all');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(lines.length, 0);
+});
+
+test('empty input is silent and exits 0', () => {
+  const { code, lines } = runCaptured('');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(lines.length, 0);
+});
+
+section('runs through hook-runner in every profile');
+
+for (const profile of ['minimal', 'standard', 'strict']) {
+  test(`profile ${profile}: ask decision reaches stdout, exit 0`, () => {
+    const res = spawnSync('node', [path.join(HOOKS, 'hook-runner.js'), 'issue-guard'], {
+      input: bashEvent('gh issue create --title t'),
+      env: { ...process.env, ENVOY_HOOK_PROFILE: profile },
+      encoding: 'utf8',
+    });
+    assert.strictEqual(res.status, 0);
+    const out = JSON.parse(res.stdout.trim());
+    assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'ask');
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Summary
+// ═══════════════════════════════════════════════════════════════════
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

New plugin-level PreToolUse[Bash] hook `issue-guard`: any Bash command containing `gh issue create` gets `permissionDecision: "ask"`, forcing a manual approval prompt — even when a permission allowlist (e.g. `Bash(gh *)` or `Bash(*)`) would otherwise let it run silently.

**Why:** the model deciding mid-task "this deserves its own issue" and self-creating it fragments work across issues nobody asked for (violates first-time-right). Issues should be born through brainstorm/hotfix after the user says go. This guard doesn't block those flows — the user just approves the prompt they initiated.

## Design

- Active in **all profiles** (minimal/standard/strict) — near-zero false-positive rate, so it ships armed rather than observe-first.
- **Fail-open** like the other gates: any error → exit 0, no output.
- Substring match on the command; non-Bash events and other `gh` subcommands stay silent.

## Testing

- `tests/hooks/issue-guard.test.js` — 10 cases: ask on plain + compound commands, silence for unrelated/other-gh/non-Bash events, fail-open on malformed/empty input, end-to-end through hook-runner in each profile (TDD: test committed red first).
- Full suite: 32/32 files green.

---

*Created with Envoy*